### PR TITLE
tmyt-004 add settings module and EHR configuration interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/reports/referralResponseReport/index.d.ts",
       "default": "./dist/reports/referralResponseReport/index.js"
     },
+    "./settings": {
+      "types": "./dist/settings/index.d.ts",
+      "default": "./dist/settings/index.js"
+    },
     "./tasks": {
       "types": "./dist/tasks/index.d.ts",
       "default": "./dist/tasks/index.js"
@@ -90,6 +94,9 @@
       ],
       "reports/referralResponseReport": [
         "./dist/reports/referralResponseReport/index.d.ts"
+      ],
+      "settings": [
+        "./dist/settings/index.d.ts"
       ],
       "tasks": [
         "./dist/tasks/index.d.ts"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './user';
 export * from './ehr';
 export * from './settings/facilities';
 export * from './settings/facility-registry';
+export * as settings from './settings';
 export * from './types/le'
 export * from './utils/csv/ListCSV';
 export * as pdfUtils from './utils/pdf/pdf';

--- a/src/settings/ehrConfigs.ts
+++ b/src/settings/ehrConfigs.ts
@@ -1,0 +1,50 @@
+export interface AutoReLoginConfig {
+  autoReLoginEnabled?: boolean;
+  autoReLoginTime?: number;
+  autoReLoginMaxAttempts?: number;
+  autoReLoginMaxAttemptsTimeRange?: number;
+}
+
+export interface BaseEhrConfig {
+  // General EHR fields
+  fullUrl: string;
+  loginPage: string;
+  userDataDir: string;
+  srcType: string;
+  shouldLoadMore: boolean;
+  browserAlertsToApprove?: string[];
+  timeForAlert?: number;
+  shouldSearch?: boolean;
+
+  // SNF user fields
+  snfAccountName: string;
+  snfAccountId: string;
+
+  // Credentials
+  accountId: string;
+  accountPassword: string;
+
+  // Auto re-login fields (optional)
+  autoReLoginEnabled?: boolean;
+  autoReLoginTime?: number;
+  autoReLoginMaxAttempts?: number;
+  autoReLoginMaxAttemptsTimeRange?: number;
+}
+
+export interface EpicEhrConfig extends BaseEhrConfig {
+  refreshListButtonId?: string;
+  requestType: string;
+  reportType: string;
+  markAsUnReadId: string;
+  listFrameButtonsBarSelector?: string;
+  responseIsFromHospital_sentFromStrings?: string[];
+  responseIsFromHospital_sentToStrings?: string[];
+  responseIsFromSite_sentFromStrings?: string[];
+  responseIsFromSite_sentToStrings?: string[];
+}
+
+export interface EnsocareEhrConfig extends BaseEhrConfig {
+  ensocareProviderId: string;
+}
+
+export type EhrConfigDocument = BaseEhrConfig | EpicEhrConfig | EnsocareEhrConfig;

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,2 +1,3 @@
 export * from './facilities';
 export * from './facility-registry';
+export * as ehrConfigs from './ehrConfigs';


### PR DESCRIPTION
## Summary
Introduces a new `settings` module with typed EHR (Electronic Health Record) configuration interfaces, enabling type-safe configuration for EHR integrations including auto re-login capabilities. This lays the groundwork for the TMYT-004 feature to support automatic re-login every 20 hours for Ensocare and other EHR systems.

## Scope of Changes
- **Feature**: Added `src/settings/ehrConfigs.ts` with `AutoReLoginConfig`, `BaseEhrConfig`, `EpicEhrConfig`, `EnsocareEhrConfig` interfaces and `EhrConfigDocument` union type
- **Config**: Registered the `./settings` subpath export in `package.json` (`exports` and `typesVersions`)
- **Chore**: Re-exported the new `ehrConfigs` namespace from `src/settings/index.ts` and added a top-level `settings` namespace export in `src/index.ts`

## Technical Implementation Details
A new file `src/settings/ehrConfigs.ts` defines a layered interface hierarchy for EHR configurations:

- `AutoReLoginConfig` — standalone interface capturing re-login parameters (`autoReLoginEnabled`, `autoReLoginTime`, `autoReLoginMaxAttempts`, `autoReLoginMaxAttemptsTimeRange`)
- `BaseEhrConfig` — common configuration shared across all EHR types, including general fields (`fullUrl`, `loginPage`, `srcType`), SNF user fields (`snfAccountName`, `snfAccountId`), credentials (`accountId`, `accountPassword`), and inline auto re-login fields
- `EpicEhrConfig extends BaseEhrConfig` — adds Epic-specific UI selectors and referral response matching string arrays
- `EnsocareEhrConfig extends BaseEhrConfig` — adds `ensocareProviderId`
- `EhrConfigDocument` — discriminated union type (`BaseEhrConfig | EpicEhrConfig | EnsocareEhrConfig`) for generic handling

The `settings` module is exposed both as a namespaced re-export (`export * as settings`) from the package root and as a dedicated subpath import (`list-types-public/settings`), following the existing pattern used by modules like `dashboard`, `logger`, and `tasks`.

## Testing & Validation
This PR adds type definitions only (interfaces and type aliases) with no runtime logic. Validation consists of ensuring the package compiles successfully via `npm run build` and that downstream consumers can import the new types through both `list-types-public` (namespaced) and `list-types-public/settings` (subpath) entry points.