### PR TITLE
Feature/snf-155-scarapers-list-status-gets-non-list-status-values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "list-types-public",
-  "version": "1.1.70",
+  "version": "1.1.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "list-types-public",
-      "version": "1.1.70",
+      "version": "1.1.88",
       "license": "ISC",
       "dependencies": {
         "csv-parse": "^5.6.0",

--- a/src/listStatus/classes/SystemSpecificStatusParser.ts
+++ b/src/listStatus/classes/SystemSpecificStatusParser.ts
@@ -36,7 +36,7 @@ export class SystemSpecificStatusParser{
             if(!status) {
                 return ListStatus.New;
             }
-            return this.parseEhrStatusToListStatus(status) || this.parseHospitalStatusToListStatus(status) || status;
+            return this.parseEhrStatusToListStatus(status) || this.parseHospitalStatusToListStatus(status) || ListStatus.UnMappedStatus;
         }
     
     getAllStatuses(){

--- a/src/listStatus/ehrStatus.ts
+++ b/src/listStatus/ehrStatus.ts
@@ -13,7 +13,7 @@ function getEhrStatusValues(ListStatusKey:ListStatusType){
     ]
 }
 
-
+/**@deprecated */
 export   const EHR_STATUS = {
     [ListStatus.Accepted]: getEhrStatusValues(ListStatus.Accepted),
     [ListStatus.Received]: getEhrStatusValues(ListStatus.Received),

--- a/src/listStatus/ehrStatuses/epicStatuses.ts
+++ b/src/listStatus/ehrStatuses/epicStatuses.ts
@@ -1,0 +1,19 @@
+
+import { ListStatus, StatusesMap } from "../listStatus"
+
+export   const EPIC_EHR_STATUS: StatusesMap = {
+    [ListStatus.Accepted]: ["Accepted"],
+    [ListStatus.Received]: [],
+    [ListStatus.Interested]: ["Considering"],
+    [ListStatus.Declined]: ["Declined"],
+    [ListStatus.New]: [],
+  }
+
+export   const EPIC_HOSPITAL_STATUS: StatusesMap = {
+    [ListStatus.Selected]: ["Selected"],
+    [ListStatus.NotSelected]: ["Not Selected"],
+    [ListStatus.Cancelled]: ["Canceled"],
+    [ListStatus.Closed]: [],  
+    [ListStatus.New]: ["Pending"],
+  }
+

--- a/src/listStatus/hospitalStatus.ts
+++ b/src/listStatus/hospitalStatus.ts
@@ -12,7 +12,7 @@ function getHospitalStatusValues(ListStatusKey:ListStatusType){
         ...(MEDITECH_HOSPITAL_STATUS[ListStatusKey]|| [])
     ]
 }
-
+/**@deprecated */
 export   const HOSPITAL_STATUS = {
     [ListStatus.Selected]: getHospitalStatusValues(ListStatus.Selected),
     [ListStatus.NotSelected]: getHospitalStatusValues(ListStatus.NotSelected),

--- a/src/listStatus/index.ts
+++ b/src/listStatus/index.ts
@@ -10,7 +10,11 @@ export * from "./listStatusParserFunctions";
 
 
 /**legacy exports to support moshe's code */
+/**@deprecated */
 export const ListPatientStatus = ListStatus;
+/**@deprecated */
 export const PATIENT_STATUS_PRIORITY = STATUS_ORDER;
+/**@deprecated */
 export const PATIENT_HOSPITAL_STATUS = HOSPITAL_STATUS;
+/**@deprecated */
 export const PATIENT_EHR_STATUS = EHR_STATUS;

--- a/src/listStatus/listStatus.ts
+++ b/src/listStatus/listStatus.ts
@@ -12,7 +12,7 @@ export const ListStatus =Object.freeze( {
     New: 'new',
     Admitted: 'admitted',
     ReAdmitted: 're-admitted',
-    /**this is the fallback default */
+    /**this is the fallback default for cases we encountered a status that wasn't mapped yet */
     UnMappedStatus: 'unmapped-status',
   })
   

--- a/src/listStatus/listStatus.ts
+++ b/src/listStatus/listStatus.ts
@@ -12,6 +12,8 @@ export const ListStatus =Object.freeze( {
     New: 'new',
     Admitted: 'admitted',
     ReAdmitted: 're-admitted',
+    /**this is the fallback default */
+    UnMappedStatus: 'unmapped-status',
   })
   
   export const ListSiteStatuses = Object.freeze( [
@@ -48,5 +50,5 @@ export const ListStatus =Object.freeze( {
     [ListStatus.Received]: 6,
     [ListStatus.New]: 7,
     [ListStatus.NoResponse]: 8,
-  }
-
+    [ListStatus.UnMappedStatus]: 9,
+}

--- a/src/listStatus/listStatusParserFunctions.ts
+++ b/src/listStatus/listStatusParserFunctions.ts
@@ -2,7 +2,7 @@ import { ListStatus, ListStatusType, STATUS_ORDER} from "./listStatus";
 import {EHR_STATUS} from "./ehrStatus";
 import {HOSPITAL_STATUS} from "./hospitalStatus";
 
-
+/**@deprecated */
 export function parseEhrStatusToListStatus(status:string) {
 for(const [listStatus, values] of Object.entries(EHR_STATUS)) {
     if(values.includes(status)) {
@@ -10,7 +10,7 @@ for(const [listStatus, values] of Object.entries(EHR_STATUS)) {
     }
 }
 }
-
+/**@deprecated */
 export function parseHospitalStatusToListStatus(status:string) {
 for(const [listStatus, values] of Object.entries(HOSPITAL_STATUS)) {
     if(values.includes(status)) {
@@ -19,7 +19,7 @@ for(const [listStatus, values] of Object.entries(HOSPITAL_STATUS)) {
 }
 }
 
-
+/**@deprecated */
 export function parseStatusToListStatus(status:string) {
     if(!status) {
         return ListStatus.New;

--- a/src/listStatus/listStatusParserFunctions.ts
+++ b/src/listStatus/listStatusParserFunctions.ts
@@ -24,7 +24,7 @@ export function parseStatusToListStatus(status:string) {
     if(!status) {
         return ListStatus.New;
     }
-    return parseEhrStatusToListStatus(status) || parseHospitalStatusToListStatus(status) || status;
+    return parseEhrStatusToListStatus(status) || parseHospitalStatusToListStatus(status) || ListStatus.UnMappedStatus;
 }
 
 /**

--- a/src/listStatus/systemsParserFunctions.ts
+++ b/src/listStatus/systemsParserFunctions.ts
@@ -2,6 +2,7 @@ import { SystemSpecificStatusParser } from "./classes/SystemSpecificStatusParser
 import { FOUR_NEXT_EHR_STATUS, FOUR_NEXT_HOSPITAL_STATUS } from "./ehrStatuses/4NextStatuses";
 import { AIDA_EHR_STATUS, AIDA_HOSPITAL_STATUS } from "./ehrStatuses/aidaStatuses";
 import { AIDIN_EHR_STATUS, AIDIN_HOSPITAL_STATUS } from "./ehrStatuses/aidenStatuses";
+import { EPIC_EHR_STATUS, EPIC_HOSPITAL_STATUS } from "./ehrStatuses/epicStatuses";
 import { GENERAL_EHR_STATUS, GENERAL_HOSPITAL_STATUS } from "./ehrStatuses/generalStatuses";
 import { MEDITECH_EHR_STATUS, MEDITECH_HOSPITAL_STATUS } from "./ehrStatuses/meditechStatuses";
 import { REPISODIC_EHR_STATUS, REPISODIC_HOSPITAL_STATUS } from "./ehrStatuses/repisodicStatuses";
@@ -34,4 +35,10 @@ export const aida = new SystemSpecificStatusParser(
 export const repisodic = new SystemSpecificStatusParser(
   REPISODIC_EHR_STATUS,
   REPISODIC_HOSPITAL_STATUS
+);
+
+
+export const epic = new SystemSpecificStatusParser(
+  EPIC_EHR_STATUS,
+  EPIC_HOSPITAL_STATUS
 );

--- a/src/site.ts
+++ b/src/site.ts
@@ -1,3 +1,8 @@
+import { ListStatusType } from "./listStatus/listStatus";
+
+/**
+ * @deprecated aim to use ListStatus from /listStatus.ts instead of ListPatientStatus
+ */
 export enum ListPatientStatus {
   Accepted = 'accepted',
   Received = 'received',
@@ -31,7 +36,7 @@ export interface SnfPatientResponseHistoryItemEpic {
   timestamp: string;
   timestampDate: string;
   files: string[];
-  listStatus: ListPatientStatus;
+  listStatus: ListStatusType;
 }
   
 export interface SnfPatientSite {
@@ -41,13 +46,13 @@ export interface SnfPatientSite {
   listSiteId: number;
   regionId?: number;
   siteStatus: string;
-  listSiteStatus: string;
+  listSiteStatus: ListStatusType;
   lastSiteStatusDate?: Date;
   hospitalStatus: string;
-  listHospitalStatus: string; 
+  listHospitalStatus: ListStatusType; 
   lastHospitalStatusDate?: Date;
   ehrSiteReadStatus?: boolean;
-  listStatus: string;
+  listStatus: ListStatusType;
   ehrRequestStatus:string;
   srcReadStatus: string;
   responseStatus: string;


### PR DESCRIPTION
## TL;DR
Introduces a typed `UnMappedStatus` fallback for unrecognized EHR/hospital statuses and adds Epic system status mappings, preventing raw vendor strings from leaking into the status type system.

## Summary
Status parsing previously returned the raw input string when no mapping was found, allowing arbitrary vendor-specific values to flow through as list statuses. This PR replaces that behavior with a dedicated `ListStatus.UnMappedStatus` sentinel value, ensuring all returned statuses are part of the known `ListStatusType` enum. Additionally, Epic EHR and hospital status mappings are introduced, and legacy aggregated status exports/functions are marked as deprecated in favor of the system-specific parser pattern.

## Scope of Changes
- **Feature**: Added Epic system status mappings (`EPIC_EHR_STATUS`, `EPIC_HOSPITAL_STATUS`) and registered the `epic` parser in `systemsParserFunctions.ts`
- **Bug Fix**: Both `SystemSpecificStatusParser.parseStatusToListStatus` and the standalone `parseStatusToListStatus` now return `ListStatus.UnMappedStatus` instead of the raw input string when no mapping matches
- **Refactor**: Marked legacy aggregated status objects (`EHR_STATUS`, `HOSPITAL_STATUS`) and standalone parser functions as `@deprecated`, along with legacy re-exports in `index.ts`
- **Config**: Version bump to 1.1.88

## Technical Implementation Details
A new `UnMappedStatus: 'unmapped-status'` entry was added to the frozen `ListStatus` object in `listStatus.ts`, with a corresponding priority of `9` (lowest) in `STATUS_ORDER`. 

The fallback logic in `SystemSpecificStatusParser.parseStatusToListStatus` (`classes/SystemSpecificStatusParser.ts:39`) was changed from `|| status` (returning the raw string) to `|| ListStatus.UnMappedStatus`. The same change was applied to the deprecated standalone `parseStatusToListStatus` in `listStatusParserFunctions.ts:27`.

Epic status mappings in `ehrStatuses/epicStatuses.ts` follow the established `StatusesMap` pattern, mapping Epic-specific strings (e.g., `"Considering"` -> `Interested`, `"Canceled"` -> `Cancelled`, `"Pending"` -> `New`) to canonical `ListStatus` values.

## Testing & Validation
No new tests were added or modified in this PR. Changes should be validated by:
- Confirming that status parsing for all supported systems (Meditech, Aidin, 4Next, Aida, Repisodic, General, Epic) correctly maps known statuses
- Verifying that unrecognized status strings now return `'unmapped-status'` instead of the raw input
- Ensuring downstream consumers handle `ListStatus.UnMappedStatus` appropriately