### PR TITLE
feature/SNF-256/refactor-custom-assessment-report-types

### DIFF
--- a/src/reports/customAssessmentReport/index.ts
+++ b/src/reports/customAssessmentReport/index.ts
@@ -1,4 +1,4 @@
-// Shared types for the "custom assessment report" feature.
+// Shared types for the report builder.
 // Consumed by both WorkflowServer (Mongoose model) and Workflow-Front (form +
 // wire adapters). Keep this file framework-agnostic — no mongoose, no Angular.
 //
@@ -8,18 +8,76 @@
 //   - Frontend: `PatientFilterForm` + wire adapters + UI-only lookup types,
 //     and a `CustomAssessmentReport` shell with `string` (JSON) timestamps.
 
-export const PREDICATE_TYPES = ['census', 'medicationCategory', 'order', 'diagnosis', 'payer', 'pdpm'] as const;
-export type PredicateType = typeof PREDICATE_TYPES[number];
-
-// Backward-compatible aliases for the legacy "patient filter type" naming.
-export const PATIENT_FILTER_TYPES = PREDICATE_TYPES;
-export type PatientFilterType = PredicateType;
+// ---------------------------------------------------------------------------
+// General
+// ---------------------------------------------------------------------------
 
 export const FILTER_OPERATORS = ['and', 'or'] as const;
 export type FilterOperator = typeof FILTER_OPERATORS[number];
 
-export const MONITORING_CHECK_TYPES = ['order', 'carePlan', 'assessment', 'assessmentResponse', 'pdpm', 'payer', 'diagnosis'] as const;
+export const FILTER_TYPES = ['census', 'medicationCategory', 'order', 'diagnosis', 'payer', 'pdpm'] as const;
+export type FilterType = typeof FILTER_TYPES[number];
+
+export const MONITORING_CHECK_TYPES = ['order', 'diagnosis', 'payer', 'pdpm', 'carePlan', 'assessment', 'assessmentResponse'] as const;
 export type MonitoringCheckType = typeof MONITORING_CHECK_TYPES[number];
+
+interface PatientFilterBase {
+  id: string;
+}
+
+interface MonitoringCheckBase {
+  id: string;
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Census
+// ---------------------------------------------------------------------------
+
+export interface CensusFilter extends PatientFilterBase {
+  type: 'census';
+}
+
+// ---------------------------------------------------------------------------
+// Medication category
+// ---------------------------------------------------------------------------
+
+export interface MedicationCategoryFilter extends PatientFilterBase {
+  type: 'medicationCategory';
+  categories: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Order
+// ---------------------------------------------------------------------------
+
+export interface OrderFilter extends PatientFilterBase {
+  type: 'order';
+  descriptions: string[];
+}
+
+export interface OrderMonitoringCheck extends MonitoringCheckBase {
+  type: 'order';
+  descriptions: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Diagnosis
+// ---------------------------------------------------------------------------
+
+export interface DiagnosisFilter extends PatientFilterBase {
+  type: 'diagnosis';
+  icdCodes: string[];
+}
+
+export interface DiagnosisMonitoringCheck extends MonitoringCheckBase {
+  type: 'diagnosis';
+  icdCodes?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Payer
+// ---------------------------------------------------------------------------
 
 export const PAYER_RANKS = ['primary', 'secondary'] as const;
 export type PayerRank = typeof PAYER_RANKS[number];
@@ -27,11 +85,26 @@ export type PayerRank = typeof PAYER_RANKS[number];
 export const PAYER_CHECK_MODES = ['type', 'name'] as const;
 export type PayerCheckMode = typeof PAYER_CHECK_MODES[number];
 
-export const PERIOD_RESOLUTIONS = ['month', 'quarter'] as const;
-export type PeriodResolution = typeof PERIOD_RESOLUTIONS[number];
+export interface PayerEntry {
+  rank: PayerRank;
+  payerType: string;
+  payerId?: number;
+}
 
-export const VALIDITY_PERIODS = ['week', 'month'] as const;
-export type ValidityPeriod = typeof VALIDITY_PERIODS[number];
+export interface PayerFilter extends PatientFilterBase {
+  type: 'payer';
+  entries: PayerEntry[];
+}
+
+export interface PayerMonitoringCheck extends MonitoringCheckBase {
+  type: 'payer';
+  mode: PayerCheckMode;
+  entries?: PayerEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// PDPM
+// ---------------------------------------------------------------------------
 
 export const PDPM_CATEGORIES = ['pt/ot', 'slp', 'nta', 'nursing', 'hipps'] as const;
 export type PdpmCategory = typeof PDPM_CATEGORIES[number];
@@ -39,76 +112,59 @@ export type PdpmCategory = typeof PDPM_CATEGORIES[number];
 export const PDPM_CATEGORY_LABELS: Record<PdpmCategory, string> = {
   'pt/ot': 'PT/OT',
   'slp': 'SLP',
-  'nursing': 'Nursing',
   'nta': 'NTA',
+  'nursing': 'Nursing',
   'hipps': 'HIPPS',
 };
 
+export interface PdpmEntry {
+  category: PdpmCategory;
+  group: string;
+}
+
+export interface PdpmFilter extends PatientFilterBase {
+  type: 'pdpm';
+  entries: PdpmEntry[];
+}
+
+export interface PdpmMonitoringCheck extends MonitoringCheckBase {
+  type: 'pdpm';
+  category: PdpmCategory;
+  entries?: PdpmEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Care plan
+// ---------------------------------------------------------------------------
+
+export interface CarePlanMonitoringCheck extends MonitoringCheckBase {
+  type: 'carePlan';
+  descriptions?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Assessment
+// ---------------------------------------------------------------------------
+
+export const PERIOD_RESOLUTIONS = ['month', 'quarter'] as const;
+export type PeriodResolution = typeof PERIOD_RESOLUTIONS[number];
+
+export interface AssessmentMonitoringCheck extends MonitoringCheckBase {
+  type: 'assessment';
+  descriptions: string[];
+  resolution: PeriodResolution;
+  periodCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Assessment response
+// ---------------------------------------------------------------------------
+
+export const VALIDITY_PERIODS = ['week', 'month'] as const;
+export type ValidityPeriod = typeof VALIDITY_PERIODS[number];
+
 export const ASSESSMENT_RESPONSE_OPERATORS = ['and', 'or'] as const;
 export type AssessmentResponseOperator = typeof ASSESSMENT_RESPONSE_OPERATORS[number];
-
-// ---------------------------------------------------------------------------
-// Predicate atoms — shared between PatientFilter and MonitoringCheck.
-// Each atom describes a per-patient predicate (e.g. "primary payer is type X");
-// the filter side aggregates atoms to select patients, the check side pairs an
-// atom with display semantics to render a per-cell result.
-// ---------------------------------------------------------------------------
-
-export interface OrderPredicate {
-  descriptions: string[];
-}
-
-export interface DiagnosisPredicateAtom {
-  icdCodes: string[];
-}
-
-export interface PdpmPredicate {
-  // Optional on the atom because the pdpm monitoring check allows display-only
-  // (no category set => uncoloured cell). The filter side validates it at runtime.
-  category?: PdpmCategory;
-  groups: string[];
-}
-
-export interface PayerPredicate {
-  rank: PayerRank;
-  payerId?: number;
-  payerType?: string;
-}
-
-// Backward-compatible aliases.
-export type PayerFilterEntry = PayerPredicate;
-export type PdpmFilterGroup = PdpmPredicate;
-
-// ---------------------------------------------------------------------------
-// Predicates with their discriminator added — used directly inside the filter's
-// predicates[] array.
-// ---------------------------------------------------------------------------
-
-export interface CensusPredicate { type: 'census'; }
-export interface MedicationCategoryPredicate {
-  type: 'medicationCategory';
-  categories: string[];
-}
-export interface DiagnosisPredicate extends DiagnosisPredicateAtom {
-  type: 'diagnosis';
-}
-export interface OrderFilterPredicate extends OrderPredicate { type: 'order'; }
-export interface PayerFilterPredicate extends PayerPredicate { type: 'payer'; }
-export interface PdpmFilterPredicate extends PdpmPredicate { type: 'pdpm'; }
-
-export type Predicate =
-  | CensusPredicate
-  | MedicationCategoryPredicate
-  | DiagnosisPredicate
-  | OrderFilterPredicate
-  | PayerFilterPredicate
-  | PdpmFilterPredicate;
-
-export interface PatientFilter {
-  predicates: Predicate[];
-  /** Combination logic across predicates. Defaults to 'or'. AND is reserved for the future. */
-  operator?: FilterOperator;
-}
 
 export interface AssessmentResponseQuestion {
   questionKey: string;
@@ -116,29 +172,6 @@ export interface AssessmentResponseQuestion {
   controlType: string;
   expectedValue: string;
   displayText?: string;
-}
-
-export interface MonitoringCheckBase {
-  id: string;
-  label: string;
-}
-
-export interface OrderMonitoringCheck extends MonitoringCheckBase, OrderPredicate {
-  type: 'order';
-}
-
-export interface CarePlanMonitoringCheck extends MonitoringCheckBase {
-  type: 'carePlan';
-  // TEMP: `description` is legacy; the server auto-migrates it to `descriptions` on read.
-  description?: string;
-  descriptions?: string[];
-}
-
-export interface AssessmentMonitoringCheck extends MonitoringCheckBase {
-  type: 'assessment';
-  descriptions: string[];
-  resolution: PeriodResolution;
-  periodCount: number;
 }
 
 export interface AssessmentResponseMonitoringCheck extends MonitoringCheckBase {
@@ -152,24 +185,29 @@ export interface AssessmentResponseMonitoringCheck extends MonitoringCheckBase {
   validityPeriod?: ValidityPeriod;
 }
 
-export interface PdpmMonitoringCheck extends MonitoringCheckBase, PdpmPredicate {
-  type: 'pdpm';
-}
+// ---------------------------------------------------------------------------
+// Unions and container
+// ---------------------------------------------------------------------------
 
-export interface PayerMonitoringCheck extends MonitoringCheckBase, PayerPredicate {
-  type: 'payer';
-  mode: PayerCheckMode;
-}
-
-export interface DiagnosisMonitoringCheck extends MonitoringCheckBase, DiagnosisPredicateAtom {
-  type: 'diagnosis';
-}
+export type PatientFilter =
+  | CensusFilter
+  | MedicationCategoryFilter
+  | OrderFilter
+  | DiagnosisFilter
+  | PayerFilter
+  | PdpmFilter;
 
 export type MonitoringCheck =
   | OrderMonitoringCheck
+  | DiagnosisMonitoringCheck
+  | PayerMonitoringCheck
+  | PdpmMonitoringCheck
   | CarePlanMonitoringCheck
   | AssessmentMonitoringCheck
-  | AssessmentResponseMonitoringCheck
-  | PdpmMonitoringCheck
-  | PayerMonitoringCheck
-  | DiagnosisMonitoringCheck;
+  | AssessmentResponseMonitoringCheck;
+
+export interface PatientFilters {
+  filters: PatientFilter[];
+  /** Combination logic across filters. Defaults to 'or'. AND is reserved for the future. */
+  operator?: FilterOperator;
+}


### PR DESCRIPTION
## Summary

Restructure the custom-assessment-report shared types so each domain (Census, Medication category, Order, Diagnosis, Payer, PDPM, Care plan, Assessment, Assessment response) owns its constants + entry + filter + monitoring check in one file section. The predicate-atom layer is gone; every Filter and MonitoringCheck is self-contained.

## Key shape changes

- **Filters**: `Filter` union, `PatientFilters` container with `filters: Filter[]`. Each filter `extends PatientFilterBase { id: string }` (un-exported base).
- **PayerEntry**: `{ rank, payerType (required), payerId? }`. Used by both `PayerFilter.entries[]` and `PayerMonitoringCheck.entries?[]`.
- **PdpmEntry**: `{ category, group }`. `PdpmFilter.entries: PdpmEntry[]` for multi-category match; `PdpmMonitoringCheck.entries?` for optional coloring rules; `PdpmMonitoringCheck.category` for the display column.
- **Diagnosis / Order monitoring checks**: inlined `icdCodes` / `descriptions` directly (atom layer removed).
- **`MonitoringCheckBase` and `PatientFilterBase`** are file-internal (no longer exported).