### PR TITLE
Feature/snf-232-aidin-response

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
       "types": "./dist/tasks/referralResponse/index.d.ts",
       "default": "./dist/tasks/referralResponse/index.js"
     },
+    "./tasks/referralResponse/aidin": {
+      "types": "./dist/tasks/referralResponse/aidin/index.d.ts",
+      "default": "./dist/tasks/referralResponse/aidin/index.js"
+    },
     "./tasks/referralResponse/navi": {
       "types": "./dist/tasks/referralResponse/navi/index.d.ts",
       "default": "./dist/tasks/referralResponse/navi/index.js"
@@ -110,6 +114,9 @@
       ],
       "tasks/referralResponse": [
         "./dist/tasks/referralResponse/index.d.ts"
+      ],
+      "tasks/referralResponse/aidin": [
+        "./dist/tasks/referralResponse/aidin/index.d.ts"
       ],
       "tasks/referralResponse/navi": [
         "./dist/tasks/referralResponse/navi/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "generate-exports": "node scripts/generate-exports.mjs",
     "build": "npm run generate-exports && tsc",
     "prepare": "npm run build",
+    "dev": "tsc --watch",
     "dev:link:localProject": "npm i && npm run build && npm link"
   },
   "author": "",

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -2,3 +2,4 @@ export * from './facilities';
 export * from './facility-assignment';
 export * from './facility-registry';
 export * as ehrConfigs from './ehrConfigs';
+export * from './region';

--- a/src/settings/region.ts
+++ b/src/settings/region.ts
@@ -1,0 +1,39 @@
+/** Defines the configuration for an external account stored in secret manager */
+export interface ExternalAccountConfig {
+  /** The service string that displays in the UI */
+  displayName: string;
+
+  /** The type which the credentials are stored under in the secret manager (e.g. "Aidin", "PCC") */
+  type: string;
+
+  /** The task type that is used for login validation (e.g. "referralResponse") */
+  loginTaskType: string;
+
+  /** The task subtype which is used for the credential check task (e.g. "login", "checkLogin") */
+  loginTaskSubType?: string;
+
+  /** Whether this account is visible for credential updates in the UI */
+  isEnabled: boolean;
+}
+
+export interface RegionNewVersionPages {
+  jobInfo?: boolean;
+  referralResponseReport?: boolean;
+}
+
+/** Defines which system srcTypes are enabled for the referral response feature */
+export type RegionReferralResponse = Record<string, boolean>;
+
+/** Defines the external accounts that are enabled to be stored in secret manager */
+export type RegionExternalAccounts = Record<string, ExternalAccountConfig>;
+
+/** Defines region-specific feature flags and configurations */
+export interface RegionUiSettings {
+  newVersionPages?: RegionNewVersionPages;
+
+  /** Defines which system srcTypes are enabled for the referral response feature */
+  referralResponse?: RegionReferralResponse;
+
+  /** Defines the external accounts that are enabled to be stored in secret manager */
+  externalAccounts?: RegionExternalAccounts;
+}

--- a/src/tasks/referralResponse/aidin/constants.ts
+++ b/src/tasks/referralResponse/aidin/constants.ts
@@ -1,0 +1,26 @@
+const AIDIN_RESPONSES = Object.freeze({
+    accept: "Pre-approve",
+    decline: "Decline",
+    underReview: "Mark as Under Review",
+});
+
+type AidinResponseOption = typeof AIDIN_RESPONSES[keyof typeof AIDIN_RESPONSES];
+
+const AIDIN_RESPONSES_STATUS_CODE = Object.freeze({
+  [AIDIN_RESPONSES.accept]: "available",
+  [AIDIN_RESPONSES.decline]: "unavailable",
+  [AIDIN_RESPONSES.underReview]: "under_review",
+});
+
+const DECLINE_REASON_GROUPS = Object.freeze({
+    clinicallyNotAppropriate: "Clinically not appropriate",
+    financialMismatch: "Financial mismatch",
+    resourcesMismatch: "Resources mismatch",
+    hospitalOrPatientChoice: "Hospital or patient choice",
+    transitionConcerns: "Concern about transition to next level of care",
+    policyCompliance: "Noncompliant with agency / facility policy",
+    other: "Other",
+});
+
+export {AIDIN_RESPONSES, AIDIN_RESPONSES_STATUS_CODE, DECLINE_REASON_GROUPS}
+export type  { AidinResponseOption};

--- a/src/tasks/referralResponse/aidin/constants.ts
+++ b/src/tasks/referralResponse/aidin/constants.ts
@@ -6,7 +6,7 @@ const AIDIN_RESPONSES = Object.freeze({
 
 type AidinResponseOption = typeof AIDIN_RESPONSES[keyof typeof AIDIN_RESPONSES];
 
-const AIDIN_RESPONSES_STATUS_CODE = Object.freeze({
+const AIDIN_RESPONSES_VALUE = Object.freeze({
   [AIDIN_RESPONSES.accept]: "available",
   [AIDIN_RESPONSES.decline]: "unavailable",
   [AIDIN_RESPONSES.underReview]: "under_review",
@@ -22,5 +22,5 @@ const DECLINE_REASON_GROUPS = Object.freeze({
     other: "Other",
 });
 
-export {AIDIN_RESPONSES, AIDIN_RESPONSES_STATUS_CODE, DECLINE_REASON_GROUPS}
+export {AIDIN_RESPONSES, AIDIN_RESPONSES_VALUE  , DECLINE_REASON_GROUPS}
 export type  { AidinResponseOption};

--- a/src/tasks/referralResponse/aidin/index.ts
+++ b/src/tasks/referralResponse/aidin/index.ts
@@ -1,0 +1,32 @@
+import { Task, TaskTypes } from "../../types";
+
+export interface FacilityResponse {
+    facilityName: string;
+    response: string;
+    responseReason?: string;
+    comment?: string;
+}
+
+export interface AidinReferralResponseData {
+    referralId: string;
+    responses: { [facilityName: string]: FacilityResponse };
+}
+
+export interface AidinSelectPatientData {
+    referralId: string;
+}
+
+export type AidinSelectPatientTask = Task & {
+    srcType: "Aidin";
+    type: TaskTypes.referralResponse;
+    subType: "selectPatient";
+    data: AidinSelectPatientData;
+};
+
+export type AidinResponseTask = Task & {
+    srcType: "Aidin";
+    type: TaskTypes.referralResponse;
+    subType: "response";
+    data: AidinReferralResponseData;
+};
+

--- a/src/tasks/referralResponse/aidin/index.ts
+++ b/src/tasks/referralResponse/aidin/index.ts
@@ -1,9 +1,11 @@
 import { Task, TaskTypes } from "../../types";
-
+export * as constants from "./constants";
 export interface FacilityResponse {
     facilityName: string;
     response: string;
+    responseStatusCode: string;
     responseReason?: string;
+    responseReasonCode?: string;
     comment?: string;
 }
 
@@ -30,3 +32,5 @@ export type AidinResponseTask = Task & {
     data: AidinReferralResponseData;
 };
 
+
+export * as ResponseOptionsBuilder from "./responseOptionsBuilder";

--- a/src/tasks/referralResponse/aidin/responseOptionsBuilder.ts
+++ b/src/tasks/referralResponse/aidin/responseOptionsBuilder.ts
@@ -1,0 +1,173 @@
+import {AIDIN_RESPONSES, AIDIN_RESPONSES_STATUS_CODE, DECLINE_REASON_GROUPS, AidinResponseOption} from "./constants";
+type ResponseReasonOption = {
+    displayValue: string;
+   
+
+    value: string;
+     /** helper text of understanding the option */
+     description?: string;
+     /**group display name to display under */
+     group?: string; 
+     requireComment?: boolean;
+}
+
+
+
+type ResponseOption = {
+    statusCode: string;
+    responseReasonOptions?: ResponseReasonOption[];
+    displayValue: string;
+}
+
+
+type AidinResponseConfigs = { [key:string]:ResponseOption };
+
+function getResponseOptionStatusCodeAndDisplayValue(response: AidinResponseOption){
+  return {
+    statusCode: AIDIN_RESPONSES_STATUS_CODE[response],
+    displayValue: response
+  }
+
+}
+const aidinResponseOptions: AidinResponseConfigs = {
+    [AIDIN_RESPONSES.accept]:getResponseOptionStatusCodeAndDisplayValue(AIDIN_RESPONSES.accept),
+    [AIDIN_RESPONSES.underReview]:getResponseOptionStatusCodeAndDisplayValue(AIDIN_RESPONSES.underReview),
+      [AIDIN_RESPONSES.decline]: {
+        ...getResponseOptionStatusCodeAndDisplayValue(AIDIN_RESPONSES.decline),
+        responseReasonOptions: [
+            {
+              displayValue: "Behavioral / mental health concerns",
+              value: "mental_health_concerns",
+              group: DECLINE_REASON_GROUPS.clinicallyNotAppropriate
+            },
+            {
+              displayValue: "No following physician",
+              value: "no_following_physician",
+              group: DECLINE_REASON_GROUPS.clinicallyNotAppropriate
+            },
+            {
+              displayValue: "Medically too complex",
+              value: "medically_complex",
+              group: DECLINE_REASON_GROUPS.clinicallyNotAppropriate
+            },
+            {
+              displayValue: "Incorrect Level of Care",
+              value: "incorrect_level_of_care",
+              group: DECLINE_REASON_GROUPS.clinicallyNotAppropriate
+            },
+            {
+              displayValue: "Insufficient documentation",
+              value: "insufficient_documentation",
+              group: DECLINE_REASON_GROUPS.clinicallyNotAppropriate
+            },
+            {
+              displayValue: "Unable to accommodate requested clinical needs",
+              value: "unable_to_accommodate",
+              group: DECLINE_REASON_GROUPS.clinicallyNotAppropriate
+            },
+            {
+              displayValue: "Bad debt / owes facility money",
+              value: "bad_debt",
+              group: DECLINE_REASON_GROUPS.financialMismatch
+            },
+            {
+              displayValue: "Insurance mismatch",
+              value: "declined_insurance",
+              group: DECLINE_REASON_GROUPS.financialMismatch
+            },
+            {
+              displayValue: "No payor source",
+              value: "no_payor_source",
+              group: DECLINE_REASON_GROUPS.financialMismatch
+            },
+            {
+              displayValue: "Payor not accepted at this facility",
+              value: "payor_not_accepted",
+              group: DECLINE_REASON_GROUPS.financialMismatch
+            },
+            {
+              displayValue: "Not covered by plan",
+              value: "not_covered_by_plan",
+              group: DECLINE_REASON_GROUPS.financialMismatch
+            },
+            {
+              displayValue: "Lack of equipment resources",
+              value: "equipment_shortable",
+              group: DECLINE_REASON_GROUPS.resourcesMismatch
+            },
+            {
+              displayValue: "Staff shortage",
+              value: "staff_shortable",
+              group: DECLINE_REASON_GROUPS.resourcesMismatch
+            },
+            {
+              displayValue: "No bed",
+              value: "no_bed",
+              group: DECLINE_REASON_GROUPS.resourcesMismatch
+            },
+            {
+              displayValue: "Out of our service area",
+              value: "service_area",
+              group: DECLINE_REASON_GROUPS.resourcesMismatch
+            },
+            {
+              displayValue: "Item not offered",
+              value: "item_not_offered",
+              group: DECLINE_REASON_GROUPS.resourcesMismatch
+            },
+            {
+              displayValue: "Discharged to another facility",
+              value: "discharged_elsewhere",
+              group: DECLINE_REASON_GROUPS.hospitalOrPatientChoice
+            },
+            {
+              displayValue: "Cancelled by requesting facility",
+              value: "request_cancelled",
+              group: DECLINE_REASON_GROUPS.hospitalOrPatientChoice
+            },
+            {
+              displayValue: "Known with other agency / facility",
+              value: "known_elsewhere",
+              group: DECLINE_REASON_GROUPS.hospitalOrPatientChoice
+            },
+            {
+              displayValue: "Patient declined care with this facility",
+              value: "declined_care_with_this_facility",
+              group: DECLINE_REASON_GROUPS.hospitalOrPatientChoice
+            },
+            {
+              displayValue: "Homeless",
+              value: "homeless",
+              group: DECLINE_REASON_GROUPS.transitionConcerns
+            },
+            {
+              displayValue: "Needs long term bed",
+              value: "needs_long_term_bed",
+              group: DECLINE_REASON_GROUPS.transitionConcerns
+            },
+            {
+              displayValue: "Discharge plan safety concern",
+              value: "discharge_plan_safety_concern",
+              group: DECLINE_REASON_GROUPS.transitionConcerns
+            },
+            {
+              displayValue: "Noncompliant with agency / facility policy",
+              value: "policy_compliance",
+              group: DECLINE_REASON_GROUPS.policyCompliance
+            },
+            {
+              displayValue: "Other",
+              value: "other",
+              group: DECLINE_REASON_GROUPS.other,
+              requireComment:true
+            }
+          ]
+      },
+
+}
+
+function getAidinResponseOptionsConfigs() {
+    return aidinResponseOptions;
+}
+
+export {  AIDIN_RESPONSES , DECLINE_REASON_GROUPS, ResponseOption, ResponseReasonOption, AidinResponseConfigs ,getAidinResponseOptionsConfigs  };

--- a/src/tasks/referralResponse/aidin/responseOptionsBuilder.ts
+++ b/src/tasks/referralResponse/aidin/responseOptionsBuilder.ts
@@ -1,4 +1,4 @@
-import {AIDIN_RESPONSES, AIDIN_RESPONSES_STATUS_CODE, DECLINE_REASON_GROUPS, AidinResponseOption} from "./constants";
+import {AIDIN_RESPONSES, AIDIN_RESPONSES_VALUE, DECLINE_REASON_GROUPS, AidinResponseOption} from "./constants";
 type ResponseReasonOption = {
     displayValue: string;
    
@@ -14,7 +14,7 @@ type ResponseReasonOption = {
 
 
 type ResponseOption = {
-    statusCode: string;
+  value: string;
     responseReasonOptions?: ResponseReasonOption[];
     displayValue: string;
 }
@@ -24,7 +24,7 @@ type AidinResponseConfigs = { [key:string]:ResponseOption };
 
 function getResponseOptionStatusCodeAndDisplayValue(response: AidinResponseOption){
   return {
-    statusCode: AIDIN_RESPONSES_STATUS_CODE[response],
+    value: AIDIN_RESPONSES_VALUE[response],
     displayValue: response
   }
 

--- a/src/tasks/referralResponse/constants.ts
+++ b/src/tasks/referralResponse/constants.ts
@@ -1,0 +1,7 @@
+const TASK_TYPE = 'referralResponse';
+const TASK_SUB_TYPE = Object.freeze({
+    login: "login",
+    selectPatient: "selectPatient",
+    response: "response",
+    onIdleTask:"onIdleTask",
+});

--- a/src/tasks/referralResponse/constants.ts
+++ b/src/tasks/referralResponse/constants.ts
@@ -1,5 +1,5 @@
-const TASK_TYPE = 'referralResponse';
-const TASK_SUB_TYPE = Object.freeze({
+export const TASK_TYPE = 'referralResponse';
+export const TASK_SUB_TYPE = Object.freeze({
     login: "login",
     selectPatient: "selectPatient",
     response: "response",

--- a/src/tasks/referralResponse/index.ts
+++ b/src/tasks/referralResponse/index.ts
@@ -1,1 +1,3 @@
-export * as Navi from "./navi"
+export * as Navi from "./navi";
+export * as Aidin from "./aidin"
+

--- a/src/tasks/referralResponse/index.ts
+++ b/src/tasks/referralResponse/index.ts
@@ -1,3 +1,4 @@
 export * as Navi from "./navi";
 export * as Aidin from "./aidin"
+export * as constants from "./constants";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AIDIN Referral Response Support

**Released by:** `@vaismav`

What’s new
- Adds first-class support for AIDIN referral responses so facilities can record referral decisions with standardized status codes and structured decline reasons.

Benefits
- Ensures consistent, auditable capture of referral decisions for reporting and integrations.
- Introduces an “Under Review” status for pending decisions.
- Collects grouped decline reasons (e.g., Clinical, Financial, Resource Constraints, Patient/Hospital Decisions, Transition Concerns, Policy Compliance, Other) and requires a comment for “Other” to improve analytics and follow-up.

Key features (non-technical)
- Facility users can mark referrals as Accept, Decline (with a detailed reason), or Under Review.
- Decline reasons are organized into clear groups for easier interpretation and reporting.
- Responses map to stable status codes to support downstream automation and integrations.

Impact / Who should know
- Product & Support: Enables richer reporting and clearer triage for referred patients; UI will need to surface the new options where referral responses are captured.
- Leadership: Improves data quality for referral workflows with minimal disruption to existing processes.
- Owner: `@vaismav`

Engineering notes (high level)
- New AIDIN-specific modules and types under src/tasks/referralResponse/aidin to define responses, reason groups, and a response-options builder.
- Added referralResponse task constants and exports, region UI settings for enabling features, and package.json exports/types to publish the new module.
- Key files: src/tasks/referralResponse/aidin/{constants.ts,index.ts,responseOptionsBuilder.ts}, src/tasks/referralResponse/{constants.ts,index.ts}, src/settings/{region.ts,index.ts}, package.json

This change is primarily an infrastructure and data-model enhancement to enable standardized referral response handling across regions and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->