### PR TITLE
feat: error category taxonomy (snf-331)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/dashboard/index.d.ts",
       "default": "./dist/dashboard/index.js"
     },
+    "./errors": {
+      "types": "./dist/errors/index.d.ts",
+      "default": "./dist/errors/index.js"
+    },
     "./excel": {
       "types": "./dist/excel/index.d.ts",
       "default": "./dist/excel/index.js"
@@ -23,10 +27,6 @@
     "./listStatus": {
       "types": "./dist/listStatus/index.d.ts",
       "default": "./dist/listStatus/index.js"
-    },
-    "./errors": {
-      "types": "./dist/errors/index.d.ts",
-      "default": "./dist/errors/index.js"
     },
     "./logger": {
       "types": "./dist/logger/index.d.ts",
@@ -85,6 +85,9 @@
     "*": {
       "dashboard": [
         "./dist/dashboard/index.d.ts"
+      ],
+      "errors": [
+        "./dist/errors/index.d.ts"
       ],
       "excel": [
         "./dist/excel/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       "types": "./dist/listStatus/index.d.ts",
       "default": "./dist/listStatus/index.js"
     },
+    "./errors": {
+      "types": "./dist/errors/index.d.ts",
+      "default": "./dist/errors/index.js"
+    },
     "./logger": {
       "types": "./dist/logger/index.d.ts",
       "default": "./dist/logger/index.js"

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,245 @@
+/**
+ * Error category taxonomy — single source of truth shared across
+ * NaviHealth (scrapers), WorkflowServer (API), and LogsCenter (dashboard).
+ *
+ * Every error that reaches the support dashboard should map to ONE category.
+ * The category carries: a plain-language meaning, a default severity, and who
+ * is expected to act. This is what turns ~200 raw/library error strings into
+ * something a non-engineer support person can understand and route.
+ *
+ * The `message` is PHI/PII-free by contract — no patient names, MRNs,
+ * DOBs, or free-text clinical detail. Technical specifics belong in the log's
+ * `data`/`stack`, not here.
+ *
+ * Phase 0 deliverable: the taxonomy only. Mapping individual raw errors to a
+ * category (the classifier) lands in a later phase; see
+ * docs/Architecture/Error Catalog.md for the message→category mapping.
+ */
+
+/** Aligns with the dashboard log `type` field. */
+export type ErrorSeverity = "info" | "warning" | "error" | "critical";
+
+/** Who is expected to act on this category. */
+export type ErrorAudience = "support" | "engineering" | "ops" | "none";
+
+export enum ErrorCategory {
+  // ---- EHR automation (NaviHealth scrapers) -----------------------------
+  /** Portal slow/down/unreachable, navigation/network timeouts. */
+  EHR_UNREACHABLE = "EHR_UNREACHABLE",
+  /** The EHR site changed; selectors/frames/buttons no longer match. */
+  EHR_LAYOUT_CHANGED = "EHR_LAYOUT_CHANGED",
+  /** Couldn't sign in — bad/expired credentials or changed login flow. */
+  EHR_LOGIN_FAILED = "EHR_LOGIN_FAILED",
+  /** A privacy prompt ("Break the Glass") blocked automatic access. */
+  EHR_PRIVACY_GATE = "EHR_PRIVACY_GATE",
+  /** Couldn't fill/submit the referral response back into the EHR. */
+  RESPONSE_SUBMIT_FAILED = "RESPONSE_SUBMIT_FAILED",
+
+  // ---- Data -------------------------------------------------------------
+  /** Expected data missing or in an unexpected shape (parse/null/undefined). */
+  DATA_INCOMPLETE = "DATA_INCOMPLETE",
+
+  // ---- Platform / config ------------------------------------------------
+  /** A facility, account, key, or env var is missing or misconfigured. */
+  CONFIG_MISSING = "CONFIG_MISSING",
+  /** Collected the data but couldn't save it to the platform/backend. */
+  UPLOAD_FAILED = "UPLOAD_FAILED",
+  /** NOT a real error — an intentional dev/prod safety stop. */
+  SAFETY_GUARD = "SAFETY_GUARD",
+
+  // ---- API (WorkflowServer) ---------------------------------------------
+  /** Authentication/authorization problem (session, API key, region). */
+  AUTH = "AUTH",
+  /** Missing or invalid request input. */
+  VALIDATION = "VALIDATION",
+  /** Requested item not found (removed or not yet synced). */
+  NOT_FOUND = "NOT_FOUND",
+  /** Conflicts with existing state (e.g. duplicate name). */
+  CONFLICT = "CONFLICT",
+  /** A dependent service failed (email, PDF, push, external API). */
+  UPSTREAM_FAILED = "UPSTREAM_FAILED",
+
+  // ---- Catch-all --------------------------------------------------------
+  /** Unexpected/uncaught failure — a real bug needing engineering. */
+  INTERNAL_BUG = "INTERNAL_BUG",
+}
+
+export interface ErrorCategoryMeta {
+  /** Short human title for the category. */
+  title: string;
+  /** Default severity bucket (overridable per log site). */
+  severity: ErrorSeverity;
+  /** Who is expected to act. */
+  audience: ErrorAudience;
+  /** Plain-language, PHI-free line shown to support. */
+  message: string;
+  /** Longer explanation for the catalog / tooltips. */
+  description: string;
+}
+
+export const ERROR_CATEGORIES: Record<ErrorCategory, ErrorCategoryMeta> = {
+  [ErrorCategory.EHR_UNREACHABLE]: {
+    title: "EHR portal unreachable",
+    severity: "error",
+    audience: "support",
+    message:
+      "The EHR portal didn't respond in time — it was likely slow or temporarily unavailable. This usually retries on its own.",
+    description:
+      "Navigation/network timeouts and connection errors while loading an EHR portal (Puppeteer navigation timeout, net::ERR_*, target closed). Often transient; if many fire at once it indicates a portal outage worth escalating.",
+  },
+  [ErrorCategory.EHR_LAYOUT_CHANGED]: {
+    title: "EHR page layout changed",
+    severity: "error",
+    audience: "engineering",
+    message:
+      "A page on the EHR site changed and our automation couldn't find what it expected. Engineering needs to update it.",
+    description:
+      "Selector / frame / button / element not found, or an element detached from the page. Almost always means the hospital changed their site and the scraper's selectors are stale.",
+  },
+  [ErrorCategory.EHR_LOGIN_FAILED]: {
+    title: "EHR login failed",
+    severity: "error",
+    audience: "support",
+    message:
+      "Couldn't sign in to the EHR — the saved credentials may be wrong or expired, or the login screen changed.",
+    description:
+      "Login failures, missing/invalid credentials, 2FA prompts, or being redirected back to the login page. Support can re-check the saved credentials for the facility first.",
+  },
+  [ErrorCategory.EHR_PRIVACY_GATE]: {
+    title: "EHR privacy gate",
+    severity: "warning",
+    audience: "support",
+    message:
+      "The EHR showed a privacy prompt ('Break the Glass') that blocked automatic access; it may need manual approval.",
+    description:
+      "The EHR raised a privacy/consent interstitial the automation couldn't clear. May require a person to approve access in the EHR.",
+  },
+  [ErrorCategory.RESPONSE_SUBMIT_FAILED]: {
+    title: "Referral response submit failed",
+    severity: "error",
+    audience: "support",
+    message:
+      "Couldn't fill or submit the referral response back into the EHR. The response form or facility setup may need checking.",
+    description:
+      "Filling/submitting a referral response failed (field not found, option not selectable, submit button missing, executing user not configured). Check the facility's referral-response configuration.",
+  },
+  [ErrorCategory.DATA_INCOMPLETE]: {
+    title: "Data incomplete or unexpected",
+    severity: "error",
+    audience: "engineering",
+    message:
+      "Expected information for this referral was missing or in an unexpected format, so processing stopped.",
+    description:
+      "Missing required fields (MRN, admission date), patient/referral not found in the source, JSON parse failures, or null/undefined dereferences. Verify the referral is complete in the source system; often needs an engineering look.",
+  },
+  [ErrorCategory.CONFIG_MISSING]: {
+    title: "Configuration missing",
+    severity: "error",
+    audience: "ops",
+    message: "A facility, account, or key is missing or misconfigured, so this couldn't run.",
+    description:
+      "Required configuration absent or invalid (SNF account id/name, auth keys, facility id, feature flags). Fix the configuration for that facility/environment.",
+  },
+  [ErrorCategory.UPLOAD_FAILED]: {
+    title: "Save to platform failed",
+    severity: "error",
+    audience: "engineering",
+    message:
+      "We collected the data but couldn't save it to the platform — usually a temporary backend or network issue.",
+    description:
+      "Non-2xx response from the WorkflowServer API, failed log POST, or invalid file on upload. Data is typically retained locally; often transient.",
+  },
+  [ErrorCategory.SAFETY_GUARD]: {
+    title: "Safety guard (not an error)",
+    severity: "info",
+    audience: "none",
+    message:
+      "Not an error — an intentional safety stop (e.g. response submission disabled in this environment).",
+    description:
+      "Deliberate guards such as refusing to submit referral responses in dev, or when a feature flag is off. These are currently logged at high severity and should be downgraded to info so they stop appearing as alerts.",
+  },
+  [ErrorCategory.AUTH]: {
+    title: "Not authorized",
+    severity: "warning",
+    audience: "support",
+    message: "The request wasn't authorized — a sign-in, API key, or region-permission issue.",
+    description:
+      "Missing/invalid Authorization header or API key, unauthenticated request, or a user lacking access to a region/facility (HTTP 401/403).",
+  },
+  [ErrorCategory.VALIDATION]: {
+    title: "Invalid request",
+    severity: "warning",
+    audience: "support",
+    message: "The request was missing required information or had invalid values.",
+    description: "Client input failed validation — missing required fields, wrong types, out-of-range values (HTTP 400).",
+  },
+  [ErrorCategory.NOT_FOUND]: {
+    title: "Not found",
+    severity: "warning",
+    audience: "support",
+    message: "The requested item couldn't be found — it may have been removed or not yet synced.",
+    description: "A referral, patient, facility, label, or config record referenced by id does not exist (HTTP 404).",
+  },
+  [ErrorCategory.CONFLICT]: {
+    title: "Conflict with existing data",
+    severity: "warning",
+    audience: "support",
+    message: "This conflicts with something that already exists (for example, a duplicate name).",
+    description: "Unique-constraint or state conflicts — duplicate names, already-existing records (HTTP 409, E11000).",
+  },
+  [ErrorCategory.UPSTREAM_FAILED]: {
+    title: "Dependent service failed",
+    severity: "error",
+    audience: "engineering",
+    message: "A service we depend on (email, PDF, notifications, or an external API) failed.",
+    description:
+      "Failure calling a downstream dependency — SendGrid/email, PDF generation, FCM push, NLP/OCR processing, or another external integration.",
+  },
+  [ErrorCategory.INTERNAL_BUG]: {
+    title: "Unexpected internal error",
+    severity: "error",
+    audience: "engineering",
+    message:
+      "An unexpected error occurred — this is a bug for engineering. Please share the referral id when escalating.",
+    description:
+      "Generic catch-all 500s, uncaught exceptions, 'failed all attempts', and other unclassified failures. Should shrink over time as specific categories are added.",
+  },
+};
+
+/** Convenience accessor. */
+export function categoryMeta(code: ErrorCategory): ErrorCategoryMeta {
+  return ERROR_CATEGORIES[code];
+}
+
+/**
+ * A categorized error *instance* — what you produce when an error is tagged.
+ *
+ * The `code` supplies the friendly, PHI-free `message`/severity/audience (from
+ * the catalog); `reason` keeps the ORIGINAL error text verbatim so engineers
+ * never lose it. Friendly message and original reason coexist — the friendly
+ * one is the headline, the reason sits underneath. Never overwrite the original.
+ */
+export interface CategorizedError {
+  /** Which category this maps to. */
+  code: ErrorCategory;
+  /** Original error message, verbatim — e.g. "Navigation timeout of 30000 ms exceeded". */
+  reason?: string;
+  /** Structured, PHI-free technical context for drill-down. */
+  detail?: Record<string, unknown>;
+}
+
+/** What the dashboard renders: the catalog meta + the original reason/detail. */
+export interface ResolvedError extends ErrorCategoryMeta {
+  code: ErrorCategory;
+  /** Original error message, verbatim — shown under the friendly `message`. */
+  reason?: string;
+  detail?: Record<string, unknown>;
+}
+
+/**
+ * Resolve a categorized error into the full view: the catalog's friendly
+ * `message` (headline) plus the original `reason` (technical line underneath).
+ */
+export function describeError(err: CategorizedError): ResolvedError {
+  return { code: err.code, ...ERROR_CATEGORIES[err.code], reason: err.reason, detail: err.detail };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export * as logs from './logger/index';
 export * as user from './user/index';
 export * as reports from './reports/index';
 export * as dashboard from './dashboard/index';
+export * as errors from './errors/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
-    "compilerOptions": {
-      "outDir": "dist",
-      "module": "CommonJS",
-      "target": "ES6",
-      "declaration": true,
-      "declarationMap": true,
-      "sourceMap": true,
-      "strict": true,
-      "esModuleInterop": true,
-    },
-    "include": ["src"],
-    "exclude": ["node_modules", "dist"]
-  }
-  
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "target": "ES6",
+    "lib": ["ES2017"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
**Phase 0** of the "improve our logs" effort (SNF-331). Adds a shared **error-category taxonomy** so the support team can understand the errors they see in the LogsCenter dashboard. This is the single source of truth that later phases (dashboard rendering, source-side tagging) build on.

## What's in it
- **`ErrorCategory`** enum — 15 categories spanning the scraper (NaviHealth) and API (WorkflowServer) error surfaces: `EHR_UNREACHABLE`, `EHR_LAYOUT_CHANGED`, `EHR_LOGIN_FAILED`, `EHR_PRIVACY_GATE`, `RESPONSE_SUBMIT_FAILED`, `DATA_INCOMPLETE`, `CONFIG_MISSING`, `UPLOAD_FAILED`, `SAFETY_GUARD`, `AUTH`, `VALIDATION`, `NOT_FOUND`, `CONFLICT`, `UPSTREAM_FAILED`, `INTERNAL_BUG`.
- **`ERROR_CATEGORIES`** — per-category metadata: `{ title, severity, audience, message, description }`. `message` is the plain-language, PHI-free line shown to support; `audience` says who acts (support / engineering / ops / none).
- **`CategorizedError` / `ResolvedError` + `describeError()`** — pairs the static category (friendly message) with the **original error `reason`** kept verbatim, so engineers never lose detail. Friendly headline + original reason coexist.
- Wired via `src/index.ts` (`export * as errors`) and a `./errors` subpath in `package.json` exports.

## Scope / non-goals
- **Taxonomy only.** No consumers yet, and the package is **not built/published** in this PR — publishing happens when the first consumer (Phase 2) needs it.
- Message→category mapping for the ~200 real errors, the before→after table, and the rollout plan live in `docs/Architecture/Error Catalog.md` (vault doc, not in this repo).

## Test plan
- [x] `tsc --noEmit --strict` on `src/errors/index.ts` passes
- [x] `package.json` is valid JSON; `./errors` export mirrors existing module entries
- [ ] Reviewer: confirm taxonomy home (`list-types-public`) and category set before consumers are wired in Phase 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

### What’s New
**Phase 0: Error Category Taxonomy**—a foundational update to improve how our LogsCenter dashboard errors are understood and acted on by the support team.

### Why It Matters
Errors are now organized into **15 consistent categories**, each with:
- A **plain-language, PHI-free** support message
- A **severity level** (info → critical)
- Clear **guidance on who should act** (support, engineering, ops, or no action)
- A structured description to standardize responses

### Impact
- **No end-user or dashboard changes yet**—this is infrastructure only.
- Prepares the system to map and roll out **~200 real error scenarios** in later phases.

### Developer-Facing Update
- Added a shared **`errors` module** (including category metadata and helpers like `describeError`) and a new **package subpath export (`./errors`)** for future consumers.

**Authored by:** `@Vova` Stern  
**Autofix by:** CodeRabbit (packaging/TypeScript config updates)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->