### PR TITLE
feature/SNF-348/report-builder-roles-access

### DIFF
--- a/src/user/roles.helper.ts
+++ b/src/user/roles.helper.ts
@@ -1,15 +1,11 @@
-export const ROLE_NUMBER_FACILITY_ADMIN = 152;
+export const ROLE_NUMBER_CI = 141; // CI/Liason (Full Access)
+export const ROLE_NUMBER_CLINICAL = 144; // Clinical
+export const ROLE_NUMBER_CLINICAL_MANAGER = 145; // Clinical Manager (Manage Users)
+export const ROLE_NUMBER_ADMINISTRATOR = 151; // Administrator (Reports Only)
+export const ROLE_NUMBER_CI_MANAGER = 152; // Manager (Admin Access + Second Approval + Extra Reports)
 export const ROLE_NUMBER_SNF_ADMIN = 177;
 export const ROLE_NUMBER_SUPER_ADMIN_MIN = 701;
 export const ROLE_NUMBER_SUPER_ADMIN_MAX = 900;
-
-export function isFacilityAdmin(roleNumber?: number | null): boolean {
-  return roleNumber === ROLE_NUMBER_FACILITY_ADMIN;
-}
-
-export function isSnfAdmin(roleNumber?: number | null): boolean {
-  return roleNumber === ROLE_NUMBER_SNF_ADMIN;
-}
 
 export function isSuperAdmin(roleNumber?: number | null): boolean {
   if (roleNumber == null) return false;
@@ -17,5 +13,20 @@ export function isSuperAdmin(roleNumber?: number | null): boolean {
 }
 
 export function isAdmin(roleNumber?: number | null): boolean {
-  return isFacilityAdmin(roleNumber) || isSnfAdmin(roleNumber) || isSuperAdmin(roleNumber);
+  if (roleNumber == null) return false;
+  return (
+    isSuperAdmin(roleNumber) ||
+    roleNumber === ROLE_NUMBER_SNF_ADMIN ||
+    roleNumber === ROLE_NUMBER_CI_MANAGER
+  );
+}
+
+export function isReportsAdmin(roleNumber?: number | null): boolean {
+  if (roleNumber == null) return false;
+  return (
+    isSuperAdmin(roleNumber) ||
+    roleNumber === ROLE_NUMBER_SNF_ADMIN ||
+    roleNumber === ROLE_NUMBER_CI_MANAGER ||
+    roleNumber === ROLE_NUMBER_CLINICAL_MANAGER
+  );
 }

--- a/src/user/roles.helper.ts
+++ b/src/user/roles.helper.ts
@@ -27,6 +27,7 @@ export function isReportsAdmin(roleNumber?: number | null): boolean {
     isSuperAdmin(roleNumber) ||
     roleNumber === ROLE_NUMBER_SNF_ADMIN ||
     roleNumber === ROLE_NUMBER_CI_MANAGER ||
+    roleNumber === ROLE_NUMBER_ADMINISTRATOR ||
     roleNumber === ROLE_NUMBER_CLINICAL_MANAGER
   );
 }


### PR DESCRIPTION
SNF-348 - role helpers for Report Builder access.

- Add front-aligned role-number constants: `ROLE_NUMBER_CI` (141), `ROLE_NUMBER_CLINICAL` (144), `ROLE_NUMBER_CLINICAL_MANAGER` (145), `ROLE_NUMBER_ADMINISTRATOR` (151), `ROLE_NUMBER_CI_MANAGER` (152).
- Add `isReportsAdmin` = the report-manager set {145, 151, 152, 177, super}; keep generic `isAdmin` ({152, 177, super}) for non-report admin gates.
- Drop unused `isFacilityAdmin`/`isSnfAdmin`.

Consumed by the WorkflowServer + Workflow-Front SNF-348 PRs via branch ref (not a tagged release yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Role-Based Access for Report Management

**What's New**

We've updated the system's role and permissions structure to provide more granular access control for report management functionality. The platform now recognizes and properly authenticates five distinct role levels for Report Builder access.

**What This Means**

Report management functionality is now available to users with the following roles:
- **Super Admins** (Full system access)
- **SNF Admins** (System-level management)
- **Administrators** (Reports management)
- **CI Managers** (Manager-level access with report capabilities)
- **Clinical Managers** (User and report management)

General administrative functions continue to be restricted to Super Admins, SNF Admins, and CI Managers.

**Impact**

This change enhances security and access control by creating separate permission levels for:
- Report-specific administration (`isReportsAdmin`)
- General system administration (`isAdmin`)

Users with Administrator or Clinical Manager roles can now properly access and manage reports through designated interfaces. The system will prevent unauthorized access to administrative functions while enabling appropriate users to perform report-related tasks.

**Responsible Party**

`@Arie` Simah (arie.simah@snfai.com)

---

*Note: This change is currently integrated via development branches in related repositories and is not yet part of a published release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->