### PR TITLE
fix/SNF-330/navi-executing-user-by-listsiteid

### DIFF
--- a/src/tasks/referralResponse/navi/index.ts
+++ b/src/tasks/referralResponse/navi/index.ts
@@ -4,7 +4,7 @@ type NaviReferralResponseTaskData = {
     facilityName:string;
     response:string;
     responseReason:string;
-
+    listSiteId:number;
 }
 
 type ResponseReasonOption = {

--- a/src/tasks/referralResponse/navi/index.ts
+++ b/src/tasks/referralResponse/navi/index.ts
@@ -4,7 +4,9 @@ type NaviReferralResponseTaskData = {
     facilityName:string;
     response:string;
     responseReason:string;
-    listSiteId:number;
+    // Optional: the producer cannot always resolve it and pre-change tasks lack
+    // it. The server treats an absent value as an unresolvable (soft) task.
+    listSiteId?:number;
 }
 
 type ResponseReasonOption = {


### PR DESCRIPTION
SNF-330: shared type change for the Navi referral-response task.

Adds `listSiteId: number` to `NaviReferralResponseTaskData` so the task carries the stable site identifier end to end, letting the server resolve the executing user by id instead of the free-text site name.

Part of a 3-PR change:
- list-types-public (this PR): the type field
- WorkflowServer: resolve executing user by listSiteId
- Workflow-Front: send listSiteId on the task

Merge and publish first; the server and front consume the new field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

### Navi referral tasks now carry a stable Site ID (optional)

**Version:** list-types-public  
**Contributor:** `@Arie Simah`

#### Overview
To improve reliability in referral processing, we’ve extended the Navi referral task data with a stable numeric **Site ID**. This helps the system identify the executing user using an ID instead of relying on free-text facility/site names.

#### What’s Changed
- Added `listSiteId?: number` to the shared `NaviReferralResponseTaskData` data model
- `listSiteId` is **optional**: older tasks (or producers that can’t provide it) will continue to work, and missing values will be treated as an **unresolvable/soft** case rather than failing the workflow

#### Why It Matters (Business Impact)
- **More accurate matching:** Reduces errors caused by inconsistent facility/site names
- **Better data consistency:** Supports end-to-end tracking with a stable identifier
- **Safe rollout:** Backwards-compatible—no disruption if the ID is missing

#### Rollout Coordination
This shared type update is designed to be consumed by the coordinated next updates in **WorkflowServer** and **Workflow-Front**.

---
*Contributed by:* Arie Simah (arie.simah@snfai.com)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->