### PR TITLE
feat: canManageUserCredentials role helper (snf-370)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "list-types-public",
-  "version": "1.1.99",
+  "version": "1.1.101",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/user/roles.helper.ts
+++ b/src/user/roles.helper.ts
@@ -19,3 +19,12 @@ export function isSuperAdmin(roleNumber?: number | null): boolean {
 export function isAdmin(roleNumber?: number | null): boolean {
   return isFacilityAdmin(roleNumber) || isSnfAdmin(roleNumber) || isSuperAdmin(roleNumber);
 }
+
+// Authorization for managing another user's stored EHR credentials (SNF-370):
+// the SNF-admin tier (177) and every higher tier may act on a foreign user's
+// credentials. Deliberately excludes facility admin (152) — it sits below the
+// SNF-admin tier — so this is intentionally narrower than `isAdmin`.
+export function canManageUserCredentials(roleNumber?: number | null): boolean {
+  if (roleNumber == null) return false;
+  return roleNumber >= ROLE_NUMBER_SNF_ADMIN;
+}


### PR DESCRIPTION
## What
Adds `canManageUserCredentials(roleNumber)` to `src/user/roles.helper.ts` — returns true for `roleNumber >= ROLE_NUMBER_SNF_ADMIN` (177).

## Why
SNF-370 needs to authorize managing **another user's** stored EHR credentials (getCode / setCredentialStatus / saveCode in WorkflowServer). Product's rule: SNF-admin tier (177) and above. This is intentionally **narrower than `isAdmin`**, which also allows facility admin (152) — facility admins must NOT manage other users' credentials.

`isAdmin` is unchanged (used in ~20 other places); this is an additive new helper.

## Consumer
WorkflowServer #314 bumps its pin to `#1.1.101` and swaps the credential gate from `isAdmin` to `canManageUserCredentials`. Tag `1.1.101` is pushed so the pin resolves.

## Notes
- `dist/` is gitignored and built on install via `prepare`.
- Version bumped 1.1.99 → 1.1.101.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Release notes:

- Added a new permission check so only SNF-admin level users and above can manage another user’s stored EHR credentials.
- This is more restrictive than the general admin access check, which remains unchanged.
- Updated the package version to 1.1.101.

`@VovaStern`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->