### PR TITLE
feat: shared TaskStatusCode + AvailableSite types for EHR site sync (snf-378)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "list-types-public",
-  "version": "1.1.102",
+  "version": "1.1.103",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -31,6 +31,39 @@ export interface TaskMessage {
     read: boolean;
 }
 
+/**
+ * Canonical free-form `statusCode` values a scraper may report back to the
+ * backend (via updateTaskProcessStatus) and that the frontend then reads off
+ * the polled task. Kept as string-valued members so existing string literals
+ * (e.g. "placed_elsewhere") stay assignable; `Task.statusCode` remains `string`
+ * for back-compat.
+ */
+export enum TaskStatusCode {
+    PlacedElsewhere = 'placed_elsewhere',
+    PatientNotFound = 'patient_not_found',
+    SiteNotFound = 'site_not_found',
+}
+
+/**
+ * A recipient site as the EHR actually reports it during the
+ * login / selectPatient check. Carried inside `Task.callbackData`.
+ */
+export interface AvailableSite {
+    siteName: string;
+    responseStatus?: string;
+    respondByDate?: string;
+    lastActivityDate?: string;
+}
+
+/**
+ * Shape of the `callbackData` payload produced by the selectPatient login-check
+ * step. `callbackData` on `Task` stays `any` for back-compat; consumers can
+ * narrow to this when reading the selectPatient result.
+ */
+export interface SelectPatientCallbackData {
+    availableSites?: AvailableSite[];
+}
+
 
 
 export interface Task <STEP_STATUS extends string = string, STEP_TYPE extends object = {}, SUB_TYPE extends string = string> {
@@ -45,6 +78,7 @@ export interface Task <STEP_STATUS extends string = string, STEP_TYPE extends ob
     taskStartTime?: Date;
     taskEndTime?: Date | string;
     status?: string;
+    /** Free-form; see {@link TaskStatusCode} for known values. Kept as string for back-compat. */
     statusCode?: string;
     currentStep?: string;
     steps?: STEP_TYPE[];


### PR DESCRIPTION
## What
Adds canonical shared types for SNF-378 (referral-response EHR site sync):

- **`TaskStatusCode`** enum — `placed_elsewhere`, `patient_not_found`, and the new **`site_not_found`** (string-valued; existing string literals stay assignable).
- **`AvailableSite`** — a recipient site as the EHR actually reports it during the login/selectPatient check (`siteName` + optional status/date fields), carried in `Task.callbackData`.
- **`SelectPatientCallbackData`** — `{ availableSites?: AvailableSite[] }`, the shape consumers narrow `callbackData` to.
- JSDoc note on `Task.statusCode` pointing to `TaskStatusCode`.

`Task.statusCode` and `callbackData` stay loosely typed (`string` / `any`) for back-compat — consumers opt in to narrowing. Version bumped **1.1.102 → 1.1.103**.

## Why
SNF-378 fetches the EHR's real recipient sites during the login check and fixes a silent hang when responding to a site the EHR no longer lists. These types are the source-of-truth groundwork; NaviHealth (scraper) and Workflow-Front consume the same string contract (`site_not_found`) and `availableSites` shape.

## Notes
- Additive only — no existing signatures changed.
- `npm run generate-exports` is a no-op (new types ride the existing `export * from './tasks/types'`).
- Not yet adopted by consumers (they use local copies until this publishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Release notes

- Added shared status values for referral-response site sync, including a new `site_not_found` outcome.
- Added new shared data shapes for EHR login/select-patient flows, including support for listing available sites.
- Kept existing task fields backward compatible so current integrations continue to work.
- Bumped the package version from `1.1.102` to `1.1.103`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->