### PR TITLE
feat: add smsEnabled flag to RegionUiSettings for SMS availability

### DIFF
--- a/src/settings/region.ts
+++ b/src/settings/region.ts
@@ -36,4 +36,7 @@ export interface RegionUiSettings {
 
   /** Defines the external accounts that are enabled to be stored in secret manager */
   externalAccounts?: RegionExternalAccounts;
+
+  /** Whether SMS is available for this region (drives client SMS UI visibility). Absent/false ⇒ unavailable. */
+  smsEnabled?: boolean;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Release notes
- Added a new region-level setting to indicate whether SMS is available in a given region.
- If this setting is missing or turned off, SMS should be treated as unavailable.

**Responsible:** `@MichalSnfAI`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->