### PR TITLE
feat: model notifyOnComment as { enabled, delivery } preference

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -38,9 +38,13 @@ export interface UserSettings {
   uiSettings: UiSettings;
 }
 
+export interface NotifyOnCommentPreference {
+  enabled: boolean;
+  delivery: string[];
+}
+
 export interface UserNotificationPreferences {
-  notifyOnComment?: boolean;
-  
+  notifyOnComment?: NotifyOnCommentPreference;
 }
 
 export interface UiSettings {


### PR DESCRIPTION
Replace the boolean notifyOnComment with NotifyOnCommentPreference ({ enabled, delivery }) so comment notifications support per-channel (email/text) delivery, matching the facility notification rule shape.