### PR TITLE
feat: add canManageIntegrationApiKey role helper (snf-383)

### DIFF
--- a/src/user/roles.helper.ts
+++ b/src/user/roles.helper.ts
@@ -42,3 +42,11 @@ export function canManageUserCredentials(roleNumber?: number | null): boolean {
   if (roleNumber == null) return false;
   return roleNumber >= ROLE_NUMBER_SNF_ADMIN;
 }
+
+// Who may manage integration API keys / secrets (e.g. the Approved Admissions
+// eligibility key, SNF-383). Same SNF-admin tier (177+) as credential management,
+// but a distinct capability so the two can diverge later without coupling.
+export function canManageIntegrationApiKey(roleNumber?: number | null): boolean {
+  if (roleNumber == null) return false;
+  return roleNumber >= ROLE_NUMBER_SNF_ADMIN;
+}


### PR DESCRIPTION
## What
Adds `canManageIntegrationApiKey(roleNumber)` to `src/user/roles.helper.ts` — SNF-admin tier (177+), a distinct capability from `canManageUserCredentials` so integration-secret management and user-credential management can diverge later without coupling.

## Why (snf-383)
The SNF-383 eligibility API key needs a role gate for who may manage integration keys. WorkflowServer currently carries a local shim (`shared/auth/roles.ts`) because it couldn't depend on an unpublished helper. Landing the canonical helper here lets WorkflowServer bump its `list-types-public` pin and delete the shim.

## Notes
- Pure additive, no breaking change; same shape/threshold as the neighbouring `canManageUserCredentials`.
- After merge, CI bumps the version + cuts the tag; WorkflowServer then bumps its pin (currently `#1.1.100`) and swaps the import.

Monday: snf-383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Release note: We added a new admin permission for managing integration API keys and secrets. This gives SNF admins and above access to integration-related secrets, separate from user credential management, so the two permissions can be adjusted independently in the future.

Responsible: Auth/Platform team

<!-- end of auto-generated comment: release notes by coderabbit.ai -->