### PR TITLE
feature/snf-449-aidin-response-refactor-to-manual-actions

### DIFF
--- a/src/tasks/referralResponse/aidin/constants.ts
+++ b/src/tasks/referralResponse/aidin/constants.ts
@@ -1,7 +1,7 @@
 const AIDIN_RESPONSES = Object.freeze({
     accept: "Pre-approve",
     decline: "Decline",
-    underReview: "Mark as Under Review",
+    underReview: "Under Review",
 });
 
 type AidinResponseOption = typeof AIDIN_RESPONSES[keyof typeof AIDIN_RESPONSES];

--- a/src/tasks/referralResponse/aidin/index.ts
+++ b/src/tasks/referralResponse/aidin/index.ts
@@ -6,7 +6,7 @@ export interface FacilityResponse {
     responseStatusCode: string;
     responseReason?: string;
     responseReasonCode?: string;
-    responseReasonGroup?: string;
+    responseReasonCategory?: string;
     comment?: string;
 }
 

--- a/src/tasks/referralResponse/aidin/index.ts
+++ b/src/tasks/referralResponse/aidin/index.ts
@@ -6,6 +6,7 @@ export interface FacilityResponse {
     responseStatusCode: string;
     responseReason?: string;
     responseReasonCode?: string;
+    responseReasonGroup?: string;
     comment?: string;
 }
 


### PR DESCRIPTION
adding responseReasonGroup to aidin referralResponse data object to help the automatioh quickly get the category of the response reason  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Release Notes: Aidin Referral Response Enhancements

- **Improved response categorization (automation support):** Added an optional **“Response Reason Category”** field to Aidin referral responses so automated tools can more quickly identify the response reason type.
- **Updated “Under Review” wording:** Changed the Aidin **Under Review** option label to **“Under Review”** (cleaner/shorter wording) while keeping the underlying value the same.

**Tags:** `@vaismav`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->