### PR TITLE
feature/SNF-458/report-builder-period-resolutions

### DIFF
--- a/src/reports/customAssessmentReport/index.ts
+++ b/src/reports/customAssessmentReport/index.ts
@@ -149,8 +149,8 @@ export interface CarePlanMonitoringCheck extends MonitoringCheckBase {
 export const PERIOD_RESOLUTIONS = ['week', 'month', 'quarter', 'year'] as const;
 export type PeriodResolution = typeof PERIOD_RESOLUTIONS[number];
 
-// Yearly is not a "last N periods" resolution; it is one of two fixed windows.
-// Only meaningful when resolution === 'year'; ignored otherwise.
+// Only used when resolution === 'year' (periodCount is ignored for year). Two fixed windows:
+// 'ytd' = start of calendar year to now; 'trailing12' (the default when absent) = rolling last 12 months.
 export const YEAR_MODES = ['trailing12', 'ytd'] as const;
 export type YearMode = typeof YEAR_MODES[number];
 

--- a/src/reports/customAssessmentReport/index.ts
+++ b/src/reports/customAssessmentReport/index.ts
@@ -146,21 +146,27 @@ export interface CarePlanMonitoringCheck extends MonitoringCheckBase {
 // Assessment
 // ---------------------------------------------------------------------------
 
-export const PERIOD_RESOLUTIONS = ['month', 'quarter'] as const;
+export const PERIOD_RESOLUTIONS = ['week', 'month', 'quarter', 'year'] as const;
 export type PeriodResolution = typeof PERIOD_RESOLUTIONS[number];
+
+// Yearly is not a "last N periods" resolution; it is one of two fixed windows.
+// Only meaningful when resolution === 'year'; ignored otherwise.
+export const YEAR_MODES = ['trailing12', 'ytd'] as const;
+export type YearMode = typeof YEAR_MODES[number];
 
 export interface AssessmentMonitoringCheck extends MonitoringCheckBase {
   type: 'assessment';
   descriptions: string[];
   resolution: PeriodResolution;
   periodCount: number;
+  yearMode?: YearMode;
 }
 
 // ---------------------------------------------------------------------------
 // Assessment response
 // ---------------------------------------------------------------------------
 
-export const VALIDITY_PERIODS = ['week', 'month'] as const;
+export const VALIDITY_PERIODS = ['week', 'month', 'quarter', 'year'] as const;
 export type ValidityPeriod = typeof VALIDITY_PERIODS[number];
 
 export const ASSESSMENT_RESPONSE_OPERATORS = ['and', 'or'] as const;
@@ -182,6 +188,7 @@ export interface AssessmentResponseMonitoringCheck extends MonitoringCheckBase {
   operator: AssessmentResponseOperator;
   resolution: PeriodResolution;
   periodCount: number;
+  yearMode?: YearMode;
   validityPeriod?: ValidityPeriod;
 }
 


### PR DESCRIPTION
## Summary
Extends the shared Report Builder monitoring-check types for SNF-458:
- `PERIOD_RESOLUTIONS`: adds `week` and `year` (was `month`, `quarter`).
- Adds `YEAR_MODES` (`trailing12` | `ytd`) + `YearMode`, and optional `yearMode` on the Assessment and Assessment-Response check interfaces (a single fixed window; only read when resolution is `year`).
- `VALIDITY_PERIODS`: adds `quarter` and `year` (Assessment-Response validity window).

All changes are additive and backward-compatible; existing month/quarter checks need no migration.

## Consumers
WorkflowServer and Workflow-Front consume these via the feature-branch ref during review (see their PRs). Do not merge the downstream consumers until this is merged to `main` and their deps are flipped to a published version.

Related: SNF-458.


## Related PRs (SNF-458 feature)
- list-types-public: https://github.com/LiST-Funding/list-types-public/pull/68
- WorkflowServer: https://github.com/LiST-Funding/WorkflowServer/pull/357
- Workflow-Front: https://github.com/LiST-Funding/Workflow-Front/pull/290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Release notes

- Updated shared report builder settings to support additional time ranges, including weekly and yearly reporting.
- Added yearly options for assessment checks so yearly reports can now use either rolling 12 months or year-to-date.
- Expanded assessment response validity windows to include quarterly and yearly periods.
- These changes are backward-compatible and do not require any migration.

Responsible: Arie Simah

<!-- end of auto-generated comment: release notes by coderabbit.ai -->