### PR TITLE
feature/SNF-465/event-report-builder-rth

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/reports/customAssessmentReport/index.d.ts",
       "default": "./dist/reports/customAssessmentReport/index.js"
     },
+    "./reports/eventReport": {
+      "types": "./dist/reports/eventReport/index.d.ts",
+      "default": "./dist/reports/eventReport/index.js"
+    },
     "./reports/referralResponseReport": {
       "types": "./dist/reports/referralResponseReport/index.d.ts",
       "default": "./dist/reports/referralResponseReport/index.js"
@@ -102,6 +106,9 @@
       ],
       "reports/customAssessmentReport": [
         "./dist/reports/customAssessmentReport/index.d.ts"
+      ],
+      "reports/eventReport": [
+        "./dist/reports/eventReport/index.d.ts"
       ],
       "reports/referralResponseReport": [
         "./dist/reports/referralResponseReport/index.d.ts"

--- a/src/reports/eventReport/index.ts
+++ b/src/reports/eventReport/index.ts
@@ -28,6 +28,7 @@ export const PERIOD_UNITS = ['week', 'month', 'quarter', 'year'] as const;
 export type PeriodUnit = typeof PERIOD_UNITS[number];
 
 export interface RollingWindow {
+  // Positive whole number of `unit`. Bounds (>0, integer, max span) enforced server-side.
   amount: number;
   unit: RollingUnit;
 }
@@ -70,7 +71,10 @@ export interface EventTrigger {
 }
 
 // ---------------------------------------------------------------------------
-// Additional conditions (all AND-combined)
+// Additional conditions.
+// previousEvent and admissionSource: repeatable, all AND-combined.
+// payer and destinationHospital: at-most-one each (the engine applies only the
+// first; enforced by the server validator).
 // ---------------------------------------------------------------------------
 
 export const CONDITION_TYPES = ['previousEvent', 'payer', 'destinationHospital', 'admissionSource'] as const;
@@ -96,6 +100,7 @@ interface ConditionBase {
 interface PreviousEventConditionCommon extends ConditionBase {
   type: 'previousEvent';
   actionCodeIds: number[];
+  // Positive whole number of `unit` (amountMax > amount for 'between'). Enforced server-side.
   amount: number;
   unit: GapUnit;
 }
@@ -163,5 +168,6 @@ export interface EventOutputColumn {
   key: EventColumnKey;
   label?: string;
   hidden: boolean;
+  // Authoritative over array position (the engine sorts by it); unique per report.
   order: number;
 }

--- a/src/reports/eventReport/index.ts
+++ b/src/reports/eventReport/index.ts
@@ -1,0 +1,167 @@
+// Shared types for the event-based report builder (first use case: RTH).
+// Consumed by both WorkflowServer (Mongoose model + engine) and Workflow-Front
+// (form + wire adapters). Keep this file framework-agnostic: no mongoose, no
+// Angular.
+//
+// An event report asks "which events happened inside a rolling time window,
+// plus extra filtering" and renders one row per event. This differs from the
+// customAssessmentReport, which is a current-census snapshot (one row per
+// patient). Each side keeps a thin local shell adding id/regionId/name and
+// timestamps (Date on the server, string on the frontend).
+
+// ---------------------------------------------------------------------------
+// Time window
+// ---------------------------------------------------------------------------
+
+// The window is always relative so a saved report keeps working over time.
+// 'last' = last N units up to now; 'current' = start of the current
+// week/month/quarter/year to now; 'previous' = the last complete one.
+export const WINDOW_MODES = ['last', 'current', 'previous'] as const;
+export type WindowMode = typeof WINDOW_MODES[number];
+
+// No 'hours': the whole feature is date-based. A window/gap is measured in whole
+// calendar days, never by time of day (see the engine's day-truncation).
+export const ROLLING_UNITS = ['days', 'weeks', 'months'] as const;
+export type RollingUnit = typeof ROLLING_UNITS[number];
+
+export const PERIOD_UNITS = ['week', 'month', 'quarter', 'year'] as const;
+export type PeriodUnit = typeof PERIOD_UNITS[number];
+
+export interface RollingWindow {
+  amount: number;
+  unit: RollingUnit;
+}
+
+export interface PeriodWindow {
+  unit: PeriodUnit;
+}
+
+// Discriminated on `mode`: the 'last' arm carries a RollingWindow; the
+// 'current'/'previous' arms carry a PeriodWindow.
+export interface RollingTimeWindow {
+  mode: 'last';
+  rolling: RollingWindow;
+}
+
+export interface PeriodTimeWindow {
+  mode: 'current' | 'previous';
+  period: PeriodWindow;
+}
+
+export type EventTimeWindow = RollingTimeWindow | PeriodTimeWindow;
+
+// ---------------------------------------------------------------------------
+// Trigger event (What happened + optional Destination)
+// ---------------------------------------------------------------------------
+
+// Destination is resolved from the census To/From fields. Categories are the
+// coarse phofac groups (Hospital/Home/...); types are the concrete To/From
+// item ids. Both are region-resolved ids. A row qualifies only when the action
+// code AND the destination both match (AND semantics).
+export interface EventDestination {
+  categoryItemIds?: number[];
+  typeItemIds?: number[];
+}
+
+export interface EventTrigger {
+  // Region-resolved census action code ids ("What happened").
+  actionCodeIds: number[];
+  destination?: EventDestination;
+}
+
+// ---------------------------------------------------------------------------
+// Additional conditions (all AND-combined)
+// ---------------------------------------------------------------------------
+
+export const CONDITION_TYPES = ['previousEvent', 'payer', 'destinationHospital', 'admissionSource'] as const;
+export type ConditionType = typeof CONDITION_TYPES[number];
+
+// 'between' uses amount as the lower bound and amountMax as the upper (both
+// inclusive). All measured in whole calendar days (never time of day).
+export const GAP_OPERATORS = ['lessThan', 'moreThan', 'between'] as const;
+export type GapOperator = typeof GAP_OPERATORS[number];
+
+export const GAP_UNITS = ['days', 'weeks', 'months'] as const;
+export type GapUnit = typeof GAP_UNITS[number];
+
+interface ConditionBase {
+  id: string;
+}
+
+// Whole-day gap between the trigger event and the most recent prior event whose
+// action code is one of actionCodeIds (region-resolved, same picker as the
+// trigger). E.g. RTH is "admission codes -> this transfer, less than 30 days".
+// Discriminated on `operator`: the 'between' arm requires amountMax (the upper
+// bound); the 'lessThan'/'moreThan' arms omit it.
+interface PreviousEventConditionCommon extends ConditionBase {
+  type: 'previousEvent';
+  actionCodeIds: number[];
+  amount: number;
+  unit: GapUnit;
+}
+
+export interface PreviousEventBetweenCondition extends PreviousEventConditionCommon {
+  operator: 'between';
+  amountMax: number;
+}
+
+export interface PreviousEventSimpleCondition extends PreviousEventConditionCommon {
+  operator: 'lessThan' | 'moreThan';
+}
+
+export type PreviousEventCondition =
+  | PreviousEventBetweenCondition
+  | PreviousEventSimpleCondition;
+
+// "is any of" the given payer types (region text, matches buildEventMatchStage).
+export interface PayerCondition extends ConditionBase {
+  type: 'payer';
+  payerTypes: string[];
+}
+
+// "is any of" the given destination facilities (dr_emc_ext_facilities ids).
+export interface DestinationHospitalCondition extends ConditionBase {
+  type: 'destinationHospital';
+  extFacIds: number[];
+}
+
+// "was admitted from any of" the given To/From locations. Resolved from the
+// patient's admission event's adt_tofrom (same catalog as the trigger
+// destination): categories are phofac groups, types are concrete To/From ids.
+export interface AdmissionSourceCondition extends ConditionBase {
+  type: 'admissionSource';
+  categoryItemIds?: number[];
+  typeItemIds?: number[];
+}
+
+export type EventCondition =
+  | PreviousEventCondition
+  | PayerCondition
+  | DestinationHospitalCondition
+  | AdmissionSourceCondition;
+
+// ---------------------------------------------------------------------------
+// Output columns (drag-to-reorder + show/hide)
+// ---------------------------------------------------------------------------
+
+export const EVENT_COLUMN_KEYS = [
+  'patient',
+  'facility',
+  'admissionDate',
+  'eventDate',
+  'daysToEvent',
+  'locationType',
+  'location',
+  'primaryPayerType',
+  'primaryPayerName',
+] as const;
+export type EventColumnKey = typeof EVENT_COLUMN_KEYS[number];
+
+// Each key has a fixed generic default label (derived on the consumer side).
+// `label` is an optional per-report override; when absent the default is used.
+export interface EventOutputColumn {
+  key: EventColumnKey;
+  label?: string;
+  hidden: boolean;
+  order: number;
+}

--- a/src/reports/index.ts
+++ b/src/reports/index.ts
@@ -1,2 +1,3 @@
 export * as referralResponseReport from './referralResponseReport';
 export * as customAssessmentReport from './customAssessmentReport';
+export * as eventReport from './eventReport';


### PR DESCRIPTION
Adds the `reports.eventReport` shared wire types for the event-based report builder (SNF-465), consumed by WorkflowServer and Workflow-Front. Framework-agnostic; mirrors `reports.customAssessmentReport`.

Must be published and tagged, then pinned in WorkflowServer and Workflow-Front, before those PRs can build in CI (they currently consume these types via a local npm link for dev).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release notes

- Added new framework-agnostic shared “event-based report builder” wire types at `reports.eventReport` (to complement `reports.customAssessmentReport`), defining the contract for time windows, event triggers, filters, and configurable output columns.
- Enforced/communicated event-report constraints in the shared types:
  - `payer` and `destinationHospital`: at most one each
  - `previousEvent` and `admissionSource`: repeatable
  - Amount fields must be positive whole numbers (bounds enforced server-side)
  - Column order is authoritative; column keys must be unique
- Updated package publishing so consumers (WorkflowServer + Workflow-Front) can import `reports.eventReport` via the new `./reports/eventReport` entrypoint (with matching TypeScript mappings), avoiding dev-only local `npm link` usage.

**Contributors:** Arie Simah, vaismav
<!-- end of auto-generated comment: release notes by coderabbit.ai -->