### PR TITLE
Revert "feature/snf-449-aidin-response-refactor-to-manual-actions"

### DIFF
--- a/src/tasks/referralResponse/aidin/constants.ts
+++ b/src/tasks/referralResponse/aidin/constants.ts
@@ -1,7 +1,7 @@
 const AIDIN_RESPONSES = Object.freeze({
     accept: "Pre-approve",
     decline: "Decline",
-    underReview: "Under Review",
+    underReview: "Mark as Under Review",
 });
 
 type AidinResponseOption = typeof AIDIN_RESPONSES[keyof typeof AIDIN_RESPONSES];

--- a/src/tasks/referralResponse/aidin/index.ts
+++ b/src/tasks/referralResponse/aidin/index.ts
@@ -6,7 +6,6 @@ export interface FacilityResponse {
     responseStatusCode: string;
     responseReason?: string;
     responseReasonCode?: string;
-    responseReasonCategory?: string;
     comment?: string;
 }
 


### PR DESCRIPTION
Reverts LiST-Funding/list-types-public#67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Release notes

- Reverted the referral response workflow changes introduced in PR `#67`.
- Restored the previous “Under Review” wording and referral response data behavior.

**Responsible:** `@contributor`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->