### PR TITLE
feat: add isSnfAdmin role helper (1.1.113)

### DIFF
--- a/src/user/roles.helper.ts
+++ b/src/user/roles.helper.ts
@@ -12,6 +12,12 @@ export function isSuperAdmin(roleNumber?: number | null): boolean {
   return roleNumber >= ROLE_NUMBER_SUPER_ADMIN_MIN && roleNumber <= ROLE_NUMBER_SUPER_ADMIN_MAX;
 }
 
+// Exactly the SNF-admin tier (177) — not super-admin, not the lower manager roles.
+export function isSnfAdmin(roleNumber?: number | null): boolean {
+  if (roleNumber == null) return false;
+  return roleNumber === ROLE_NUMBER_SNF_ADMIN;
+}
+
 export function isAdmin(roleNumber?: number | null): boolean {
   if (roleNumber == null) return false;
   return (


### PR DESCRIPTION
## What
Adds `isSnfAdmin(roleNumber)` to `user/roles.helper` — exactly the SNF-admin tier (177). Bumps to `1.1.113`.

## Why
SNF-380's `requireScraperOrAdmin` gate imports `isSnfAdmin` (with the existing `isSuperAdmin`) to restrict the scraper-credential endpoints to the scraper bot (177) + super-admin (701-900). No released version exported it, so WorkflowServer's SNF-380 branch failed to typecheck.

## Scope
- `src/user/roles.helper.ts`: +`isSnfAdmin`
- `package.json`: 1.1.112 → 1.1.113

No behavior change to existing helpers.

🤖 Co-authored with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Release notes

- Added support for identifying SNF administrator accounts, enabling the related scraper credential endpoints.
- Updated the package version to `1.1.113`.

**Contributors:** Unable to determine from the available context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->