### PR TITLE
feat: add Message response option to Aidin referral responses

### DIFF
--- a/src/tasks/referralResponse/aidin/constants.ts
+++ b/src/tasks/referralResponse/aidin/constants.ts
@@ -2,6 +2,7 @@ const AIDIN_RESPONSES = Object.freeze({
     accept: "Pre-approve",
     decline: "Decline",
     underReview: "Mark as Under Review",
+    message: "Message",
 });
 
 type AidinResponseOption = typeof AIDIN_RESPONSES[keyof typeof AIDIN_RESPONSES];

--- a/src/tasks/referralResponse/aidin/responseOptionsBuilder.ts
+++ b/src/tasks/referralResponse/aidin/responseOptionsBuilder.ts
@@ -17,12 +17,13 @@ type ResponseOption = {
   value: string;
     responseReasonOptions?: ResponseReasonOption[];
     displayValue: string;
+    requireComment?: boolean;
 }
 
 
 type AidinResponseConfigs = { [key:string]:ResponseOption };
 
-function getResponseOptionStatusCodeAndDisplayValue(response: AidinResponseOption){
+function getResponseOptionStatusCodeAndDisplayValue(response: keyof typeof AIDIN_RESPONSES_VALUE){
   return {
     value: AIDIN_RESPONSES_VALUE[response],
     displayValue: response
@@ -163,7 +164,13 @@ const aidinResponseOptions: AidinResponseConfigs = {
             }
           ]
       },
-
+      // Message sends a chat message to the provider site — it has no sent_referral
+      // status, so it is deliberately absent from AIDIN_RESPONSES_VALUE.
+      [AIDIN_RESPONSES.message]: {
+        value: "message",
+        displayValue: AIDIN_RESPONSES.message,
+        requireComment: true,
+      },
 }
 
 function getAidinResponseOptionsConfigs() {


### PR DESCRIPTION
Adding "Message" to the aidin referral response option.
this area defines the data the front and NaviHealth are expecting to receive