### PR TITLE
feat(SNF-493): declare aiDecisionLogicEnabled on RegionUiSettings

### DIFF
--- a/src/settings/region.ts
+++ b/src/settings/region.ts
@@ -39,4 +39,7 @@ export interface RegionUiSettings {
 
   /** Whether SMS is available for this region (drives client SMS UI visibility). Absent/false ⇒ unavailable. */
   smsEnabled?: boolean;
+
+  /** Whether the AI decision logic UI is shown for this region. Display gate only — the AI pipeline runs regardless. Absent ⇒ disabled. */
+  aiDecisionLogicEnabled?: boolean;
 }


### PR DESCRIPTION
Declares the per-region AI decision logic flag on the shared `RegionUiSettings` type.

The flag has been written by WorkflowServer and read by Workflow-Front since SNF-493 phase 2 (LiST-Funding/WorkflowServer#373, LiST-Funding/Workflow-Front#309), but was never declared here — so both sides reached it without type coverage:

- server writes through the raw string path `"uiSettings.aiDecisionLogicEnabled"`, so the key is never checked;
- frontend re-declares its own inline `aiDecisionLogicEnabled?: boolean` in `manageb/utils.service.ts`.

Every sibling key (`newVersionPages`, `referralResponse`, `externalAccounts`, `smsEnabled`) is already declared; this one was the odd one out.

Typing hygiene only — no runtime behavior, additive optional field, no existing consumer breaks. `npx tsc --noEmit` clean.

After this merges and CI publishes, the pin bump in WorkflowServer and Workflow-Front lets the frontend drop its local re-declaration.

Co-Authored with: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Release note

Added support for controlling whether AI decision logic is displayed in the regional UI. The AI pipeline continues to run as before.

**Responsible:** `@team`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->