### PR TITLE
feat(SNF-526): EnsoCare referral-response support — base task contract, response options, statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,14 @@
       "types": "./dist/tasks/referralResponse/aidin/index.d.ts",
       "default": "./dist/tasks/referralResponse/aidin/index.js"
     },
+    "./tasks/referralResponse/base": {
+      "types": "./dist/tasks/referralResponse/base/index.d.ts",
+      "default": "./dist/tasks/referralResponse/base/index.js"
+    },
+    "./tasks/referralResponse/ensocare": {
+      "types": "./dist/tasks/referralResponse/ensocare/index.d.ts",
+      "default": "./dist/tasks/referralResponse/ensocare/index.js"
+    },
     "./tasks/referralResponse/navi": {
       "types": "./dist/tasks/referralResponse/navi/index.d.ts",
       "default": "./dist/tasks/referralResponse/navi/index.js"
@@ -124,6 +132,12 @@
       ],
       "tasks/referralResponse/aidin": [
         "./dist/tasks/referralResponse/aidin/index.d.ts"
+      ],
+      "tasks/referralResponse/base": [
+        "./dist/tasks/referralResponse/base/index.d.ts"
+      ],
+      "tasks/referralResponse/ensocare": [
+        "./dist/tasks/referralResponse/ensocare/index.d.ts"
       ],
       "tasks/referralResponse/navi": [
         "./dist/tasks/referralResponse/navi/index.d.ts"

--- a/src/ehr.ts
+++ b/src/ehr.ts
@@ -9,5 +9,6 @@ export enum EhrType {
   Aidin = 'Aidin',
   EpicUMMS = 'Epic UMMS',
   EpicTrinityHealth = 'Epic Trinity-Health',
-  Aida = "Aida"
+  Aida = "Aida",
+  Ensocare = "Ensocare"
 }

--- a/src/ehr.ts
+++ b/src/ehr.ts
@@ -10,5 +10,5 @@ export enum EhrType {
   EpicUMMS = 'Epic UMMS',
   EpicTrinityHealth = 'Epic Trinity-Health',
   Aida = "Aida",
-  Ensocare = "Ensocare"
+  Ensocare = "EnsoCare"
 }

--- a/src/listStatus/ehrStatuses/ensocareStatuses.ts
+++ b/src/listStatus/ehrStatuses/ensocareStatuses.ts
@@ -1,0 +1,19 @@
+
+import { ListStatus, StatusesMap } from "../listStatus"
+
+export   const ENSOCARE_EHR_STATUS: StatusesMap = {
+    [ListStatus.Selected]: ["Booked"],
+    [ListStatus.Accepted]: ["Yes"],
+    [ListStatus.Received]: [],
+    [ListStatus.Interested]: ["Considering"],
+    [ListStatus.Declined]: ["No"],
+    [ListStatus.New]: ["Referral Received"],
+  }
+
+export   const ENSOCARE_HOSPITAL_STATUS: StatusesMap = {
+    [ListStatus.Selected]: ["Booked"],
+    [ListStatus.NotSelected]: ["Booked Elsewhere"],
+    [ListStatus.Cancelled]: ["Canceled"],
+    [ListStatus.Closed]: [],
+    [ListStatus.New]: ["Open"],
+  }

--- a/src/listStatus/systemsParserFunctions.ts
+++ b/src/listStatus/systemsParserFunctions.ts
@@ -2,6 +2,7 @@ import { SystemSpecificStatusParser } from "./classes/SystemSpecificStatusParser
 import { FOUR_NEXT_EHR_STATUS, FOUR_NEXT_HOSPITAL_STATUS } from "./ehrStatuses/4NextStatuses";
 import { AIDA_EHR_STATUS, AIDA_HOSPITAL_STATUS } from "./ehrStatuses/aidaStatuses";
 import { AIDIN_EHR_STATUS, AIDIN_HOSPITAL_STATUS } from "./ehrStatuses/aidenStatuses";
+import { ENSOCARE_EHR_STATUS, ENSOCARE_HOSPITAL_STATUS } from "./ehrStatuses/ensocareStatuses";
 import { EPIC_EHR_STATUS, EPIC_HOSPITAL_STATUS } from "./ehrStatuses/epicStatuses";
 import { GENERAL_EHR_STATUS, GENERAL_HOSPITAL_STATUS } from "./ehrStatuses/generalStatuses";
 import { MEDITECH_EHR_STATUS, MEDITECH_HOSPITAL_STATUS } from "./ehrStatuses/meditechStatuses";
@@ -41,4 +42,9 @@ export const repisodic = new SystemSpecificStatusParser(
 export const epic = new SystemSpecificStatusParser(
   EPIC_EHR_STATUS,
   EPIC_HOSPITAL_STATUS
+);
+
+export const ensocare = new SystemSpecificStatusParser(
+  ENSOCARE_EHR_STATUS,
+  ENSOCARE_HOSPITAL_STATUS
 );

--- a/src/settings/ehrConfigs.ts
+++ b/src/settings/ehrConfigs.ts
@@ -1,3 +1,5 @@
+import { EXECUTING_ACCOUNT_MODE, type ExecutingAccountMode } from "../tasks/referralResponse/constants";
+
 export interface AutoReLoginConfig {
   autoReLoginEnabled?: boolean;
   autoReLoginTime?: number;
@@ -48,3 +50,16 @@ export interface EnsocareEhrConfig extends BaseEhrConfig {
 }
 
 export type EhrConfigDocument = BaseEhrConfig | EpicEhrConfig | EnsocareEhrConfig;
+
+/**
+ * ehrConfig document of a referral-response process (e.g. "aidinResponse", "ensocareResponse").
+ * Extends the srcType's own config document — a response config carries all the fields of its
+ * srcType (e.g. `ensocareProviderId` for Ensocare) plus the response-specific fields.
+ */
+export type ResponseEhrConfigDocument = EhrConfigDocument & {
+    /** How the response process pulls tasks and which account executes them. */
+    executingAccountMode: ExecutingAccountMode;
+};
+
+export { EXECUTING_ACCOUNT_MODE };
+export type { ExecutingAccountMode };

--- a/src/tasks/referralResponse/aidin/index.ts
+++ b/src/tasks/referralResponse/aidin/index.ts
@@ -1,36 +1,21 @@
-import { Task, TaskTypes } from "../../types";
+import * as Base from "../base";
 export * as constants from "./constants";
-export interface FacilityResponse {
-    facilityName: string;
-    response: string;
+
+/** Aidin's facility response — unchanged shape, plus the new optional `ehrReferralIdOfSite`. */
+export interface FacilityResponse extends Base.FacilityResponse {
     responseStatusCode: string;
-    responseReason?: string;
     responseReasonCode?: string;
-    comment?: string;
 }
 
-export interface AidinReferralResponseData {
-    referralId: string;
-    responses: { [facilityName: string]: FacilityResponse };
-}
+/** Aidin's `response` sub-task payload. */
+export interface AidinReferralResponseData extends Base.ReferralResponseData<FacilityResponse> {}
 
-export interface AidinSelectPatientData {
-    referralId: string;
-}
+/** Aidin's `selectPatient` sub-task payload. */
+export interface AidinSelectPatientData extends Base.SelectPatientData {}
 
-export type AidinSelectPatientTask = Task & {
-    srcType: "Aidin";
-    type: TaskTypes.referralResponse;
-    subType: "selectPatient";
-    data: AidinSelectPatientData;
-};
+export type AidinSelectPatientTask = Base.SelectPatientTask<"Aidin", AidinSelectPatientData>;
 
-export type AidinResponseTask = Task & {
-    srcType: "Aidin";
-    type: TaskTypes.referralResponse;
-    subType: "response";
-    data: AidinReferralResponseData;
-};
+export type AidinResponseTask = Base.ResponseTask<"Aidin", AidinReferralResponseData>;
 
 
 export * as ResponseOptionsBuilder from "./responseOptionsBuilder";

--- a/src/tasks/referralResponse/base/index.ts
+++ b/src/tasks/referralResponse/base/index.ts
@@ -1,6 +1,8 @@
 import { Task, TaskTypes, SelectPatientCallbackData } from "../../types";
 import { TASK_SUB_TYPE } from "../constants";
 
+export * from "./responseOptions";
+
 /**
  * Re-exported for discoverability alongside the rest of the base referralResponse
  * contract. Defined in `tasks/types.ts` (not moved, to avoid relocating an existing

--- a/src/tasks/referralResponse/base/index.ts
+++ b/src/tasks/referralResponse/base/index.ts
@@ -1,0 +1,73 @@
+import { Task, TaskTypes, SelectPatientCallbackData } from "../../types";
+import { TASK_SUB_TYPE } from "../constants";
+
+/**
+ * Re-exported for discoverability alongside the rest of the base referralResponse
+ * contract. Defined in `tasks/types.ts` (not moved, to avoid relocating an existing
+ * exported symbol) — this is the shape of `Task.callbackData` produced by the
+ * selectPatient step.
+ */
+export type { SelectPatientCallbackData };
+
+/**
+ * One facility's requested response inside a response task. EHR modules extend this
+ * to add EHR-specific fields; `Navi` predates this contract and is not derived from it
+ * (see `referralResponse/navi`).
+ */
+export interface FacilityResponse {
+    /** the ehr site name as it is pesented in the the EHR.
+     * this value should be derived from the site.siteName field in the patient doc,
+     * which is the exact representation of how it is presented in the EHR. 
+     * This is important because the EHR may have multiple sites with the same name, but different site ids. The site name is used to match the response to the correct site in the EHR.
+     */
+    facilityName: string;
+    /**
+     * Id of THIS SITE'S SPECIFIC REFERRAL ENTRY on the EHR — the id the EHR's
+     * respond call targets (Ensocare: the per-facility referral row id;
+     * AllScripts: "connectionId"). NOT the EHR's facility/organization id
+     * (that belongs to siteName). One patient (mrn) + facility can accumulate
+     * multiple entries over time; the Site carries the latest known one.
+     * Optional: sites collected before enrichment (or systems without it)
+     * won't have it — handlers must fall back to live resolution.
+     */
+    ehrReferralIdOfSite?: string;
+    response: string;
+    responseStatusCode: string | number;
+    responseReason?: string;
+    responseReasonCode?: string | number;
+    comment?: string;
+}
+
+/** Base payload of a `response` sub-task. EHRs extend DATA and FacilityResponse. */
+export interface ReferralResponseData<F extends FacilityResponse = FacilityResponse> {
+    /** Our DB referral id — the patient anchor (Ensocare: visit id). Never the POST target. */
+    referralId: string;
+    responses: { [facilityName: string]: F };
+}
+
+/** Base payload of a `selectPatient` sub-task. */
+export interface SelectPatientData {
+    referralId: string;
+}
+
+/**
+ * A `response` sub-task for a given EHR source, typed over its own
+ * {@link ReferralResponseData} shape.
+ */
+export type ResponseTask<SRC extends string, DATA extends ReferralResponseData<any>> = Task & {
+    srcType: SRC;
+    type: TaskTypes.referralResponse;
+    subType: typeof TASK_SUB_TYPE.response;
+    data: DATA;
+};
+
+/**
+ * A `selectPatient` sub-task for a given EHR source, typed over its own
+ * {@link SelectPatientData} shape.
+ */
+export type SelectPatientTask<SRC extends string, DATA extends SelectPatientData = SelectPatientData> = Task & {
+    srcType: SRC;
+    type: TaskTypes.referralResponse;
+    subType: typeof TASK_SUB_TYPE.selectPatient;
+    data: DATA;
+};

--- a/src/tasks/referralResponse/base/responseOptions.ts
+++ b/src/tasks/referralResponse/base/responseOptions.ts
@@ -1,0 +1,34 @@
+/**
+ * One selectable reason under a response option.
+ * Mapping contract (what the Front writes onto the task's {@link FacilityResponse}
+ * when the user picks this reason):
+ * - `displayValue` → `FacilityResponse.responseReason`
+ * - `value`        → `FacilityResponse.responseReasonCode`
+ */
+export interface ResponseReasonOption {
+    displayValue: string;
+    value: string | number;
+    /** Helper text for understanding the option. */
+    description?: string;
+    /**in some EHRs, the reason are grouped under a specific label. this properte is used to diplay the group lable in the front 
+     * Group display name to render the option under. */
+    group?: string;
+    requireComment?: boolean;
+}
+
+/**
+ * One top-level response option (the action the provider takes).
+ * Mapping contract (what the Front writes onto the task's {@link FacilityResponse}
+ * when the user picks this option):
+ * - `displayValue` → `FacilityResponse.response`
+ * - `value`        → `FacilityResponse.responseStatusCode`
+ */
+export interface ResponseOption {
+    displayValue: string;
+    value: string | number;
+    responseReasonOptions?: ResponseReasonOption[];
+    requireComment?: boolean;
+}
+
+/** A system's full option set, keyed by the option's display name. */
+export type ResponseConfigs = { [key: string]: ResponseOption };

--- a/src/tasks/referralResponse/base/responseOptions.ts
+++ b/src/tasks/referralResponse/base/responseOptions.ts
@@ -20,11 +20,21 @@ export interface ResponseReasonOption {
  * One top-level response option (the action the provider takes).
  * Mapping contract (what the Front writes onto the task's {@link FacilityResponse}
  * when the user picks this option):
- * - `displayValue` → `FacilityResponse.response`
+ * - `displayValue` → `FacilityResponse.response` (unless `response` overrides — see below)
  * - `value`        → `FacilityResponse.responseStatusCode`
+ * - `response ?? displayValue` → `FacilityResponse.response` — the actual rule the Front
+ *   applies. Lets an option DISPLAY one label while SENDING a different, canonical
+ *   response value (e.g. a "Message Booked Referral" option that submits as a "Yes").
+ *   Options that omit `response` behave exactly as before — full backward compatibility.
  */
 export interface ResponseOption {
     displayValue: string;
+     /**
+     * Canonical response value to send instead of `displayValue`, when the option's
+     * display label and its wire value need to differ. See the mapping contract above.
+     */
+    response?: string;
+    /**the responseCode value */
     value: string | number;
     responseReasonOptions?: ResponseReasonOption[];
     requireComment?: boolean;

--- a/src/tasks/referralResponse/constants.ts
+++ b/src/tasks/referralResponse/constants.ts
@@ -5,3 +5,16 @@ export const TASK_SUB_TYPE = Object.freeze({
     response: "response",
     onIdleTask:"onIdleTask",
 });
+
+/**
+ * How a referral-response process pulls tasks and which account executes them.
+ */
+export const EXECUTING_ACCOUNT_MODE = Object.freeze({
+    /** Each task keeps its original executing user; a process opens per user and logs in with that user's personal ehrCredentials. */
+    perUserAccount: "perUserAccount",
+    /** The fetch-task API replaces the executing user with a facility-designated account; a process opens per facility account and pulls that designated user's credentials like a regular user. */
+    perFacilityAccount: "perFacilityAccount",
+    /** The fetch-task function overrides the executing user so all tasks run on a single process/account; credentials come from the ehrConfig document, the way the scraper logs in. */
+    fixedAccount: "fixedAccount",
+});
+export type ExecutingAccountMode = typeof EXECUTING_ACCOUNT_MODE[keyof typeof EXECUTING_ACCOUNT_MODE];

--- a/src/tasks/referralResponse/ensocare/constants.ts
+++ b/src/tasks/referralResponse/ensocare/constants.ts
@@ -19,3 +19,12 @@ export const ENSOCARE_RESPONSES_CODE: Record<EnsocareResponseOption, number> = O
     [ENSOCARE_RESPONSES.considering]: 3,
 });
 
+/**
+ * Display labels for options that submit as a canonical response via
+ * `ResponseOption.response` (base mapping contract: `response ?? displayValue`) rather
+ * than their own display value. No magic strings — the builder references this.
+ */
+export const ENSOCARE_MESSAGE_RESPONSES = Object.freeze({
+    messageBookedReferral: "Message Booked Referral",
+});
+

--- a/src/tasks/referralResponse/ensocare/constants.ts
+++ b/src/tasks/referralResponse/ensocare/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Our stable keys → the Ensocare response-action catalog (`actionId` 1/2/3 and the
+ * display label the Ensocare Respond UI uses for that action). Source of truth for
+ * task creation — no magic strings elsewhere; everything references this constant.
+ * See `drafts/ensocare_resposne/ensocare-response-reasons.md` for the full captured
+ * reason catalog and the hardcode + runtime-drift-guard rationale.
+ */
+export const ENSOCARE_RESPONSES = Object.freeze({
+    accept: "Yes",
+    decline: "No",
+    considering: "Considering",
+});
+
+export type EnsocareResponseOption = typeof ENSOCARE_RESPONSES[keyof typeof ENSOCARE_RESPONSES];
+
+export const ENSOCARE_RESPONSES_CODE: Record<EnsocareResponseOption, number> = Object.freeze({
+    [ENSOCARE_RESPONSES.accept]: 1,
+    [ENSOCARE_RESPONSES.decline]: 2,
+    [ENSOCARE_RESPONSES.considering]: 3,
+});
+

--- a/src/tasks/referralResponse/ensocare/index.ts
+++ b/src/tasks/referralResponse/ensocare/index.ts
@@ -1,0 +1,20 @@
+import * as Base from "../base";
+import { EnsocareResponseOption } from "./constants";
+
+/** Ensocare's facility response — the per-facility referral row id rides in `ehrReferralIdOfSite`. */
+export interface EnsocareFacilityResponse extends Base.FacilityResponse {
+    response: EnsocareResponseOption;
+    responseStatusCode: number;
+    responseReasonCode?: number; 
+    ehrReferralIdOfSite:string;
+}
+
+/** Ensocare's `response` sub-task payload. */
+export interface EnsocareReferralResponseData extends Base.ReferralResponseData<EnsocareFacilityResponse> {}
+
+/** Ensocare's `selectPatient` sub-task payload. */
+export interface EnsocareSelectPatientData extends Base.SelectPatientData {}
+
+export type EnsocareResponseTask = Base.ResponseTask<"Ensocare", EnsocareReferralResponseData>;
+
+export type EnsocareSelectPatientTask = Base.SelectPatientTask<"Ensocare", EnsocareSelectPatientData>;

--- a/src/tasks/referralResponse/ensocare/index.ts
+++ b/src/tasks/referralResponse/ensocare/index.ts
@@ -1,6 +1,7 @@
 import * as Base from "../base";
 import { EnsocareResponseOption } from "./constants";
 
+export * as constants from "./constants";
 export * as ResponseOptionsBuilder from "./responseOptionsBuilder";
 
 /** Ensocare's facility response — the per-facility referral row id rides in `ehrReferralIdOfSite`. */

--- a/src/tasks/referralResponse/ensocare/index.ts
+++ b/src/tasks/referralResponse/ensocare/index.ts
@@ -1,6 +1,8 @@
 import * as Base from "../base";
 import { EnsocareResponseOption } from "./constants";
 
+export * as ResponseOptionsBuilder from "./responseOptionsBuilder";
+
 /** Ensocare's facility response — the per-facility referral row id rides in `ehrReferralIdOfSite`. */
 export interface EnsocareFacilityResponse extends Base.FacilityResponse {
     response: EnsocareResponseOption;

--- a/src/tasks/referralResponse/ensocare/index.ts
+++ b/src/tasks/referralResponse/ensocare/index.ts
@@ -16,7 +16,9 @@ export interface EnsocareFacilityResponse extends Base.FacilityResponse {
 export interface EnsocareReferralResponseData extends Base.ReferralResponseData<EnsocareFacilityResponse> {}
 
 /** Ensocare's `selectPatient` sub-task payload. */
-export interface EnsocareSelectPatientData extends Base.SelectPatientData {}
+export interface EnsocareSelectPatientData extends Base.SelectPatientData {
+    mrn:string
+}
 
 export type EnsocareResponseTask = Base.ResponseTask<"Ensocare", EnsocareReferralResponseData>;
 

--- a/src/tasks/referralResponse/ensocare/responseOptionsBuilder.ts
+++ b/src/tasks/referralResponse/ensocare/responseOptionsBuilder.ts
@@ -1,5 +1,5 @@
 import { ResponseOption, ResponseReasonOption } from "../base/responseOptions";
-import { ENSOCARE_RESPONSES, ENSOCARE_RESPONSES_CODE, EnsocareResponseOption } from "./constants";
+import { ENSOCARE_RESPONSES, ENSOCARE_RESPONSES_CODE, ENSOCARE_MESSAGE_RESPONSES, EnsocareResponseOption } from "./constants";
 
 /** Ensocare reason option — value is the numeric catalog entry id. */
 export interface EnsocareReasonOption extends ResponseReasonOption {
@@ -270,10 +270,15 @@ function reasonOptionsForAction(actionId: number): EnsocareReasonOption[] {
     }));
 }
 
-/** displayValue/value pair of one action — mirrors aidin's helper. */
+/**
+ * displayValue/value pair of one action — mirrors aidin's helper. `response` is set
+ * explicitly even though it equals displayValue for the canonical actions: every
+ * option states what it submits, so the Front never depends on the fallback half of
+ * the `response ?? displayValue` contract.
+ */
 function buildOption(displayValue: EnsocareResponseOption): EnsocareOption {
     const value = ENSOCARE_RESPONSES_CODE[displayValue];
-    return { displayValue, value, responseReasonOptions: reasonOptionsForAction(value) };
+    return { displayValue, response: displayValue, value, responseReasonOptions: reasonOptionsForAction(value) };
 }
 
 const ensocareResponseOptions: EnsocareResponseConfigs = {
@@ -283,10 +288,25 @@ const ensocareResponseOptions: EnsocareResponseConfigs = {
     // the user is never asked to pick it.
     [ENSOCARE_RESPONSES.accept]: {
         displayValue: ENSOCARE_RESPONSES.accept,
+        response: ENSOCARE_RESPONSES.accept,
         value: ENSOCARE_RESPONSES_CODE[ENSOCARE_RESPONSES.accept],
     },
     [ENSOCARE_RESPONSES.decline]: buildOption(ENSOCARE_RESPONSES.decline),
     [ENSOCARE_RESPONSES.considering]: buildOption(ENSOCARE_RESPONSES.considering),
+    // Message on a Booked referral — displays differently but IS a Yes on the wire: the
+    // base mapping contract (`response ?? displayValue`) means the Front sends
+    // response: "Yes" / statusCode 1 when this option is picked, so the scraper's
+    // accept path (including the automation-side accept-reason enrichment) applies
+    // unchanged — no scraper code needed for this option. Literal (not buildOption) so
+    // it exposes NO reason options, like accept: the single Yes catalog reason (id 32)
+    // is appended by the automation side. Offered by the Front only when the
+    // selectPatient callback set isMessageEnabled (Booked referrals only).
+    [ENSOCARE_MESSAGE_RESPONSES.messageBookedReferral]: {
+        displayValue: ENSOCARE_MESSAGE_RESPONSES.messageBookedReferral,
+        response: ENSOCARE_RESPONSES.accept,
+        value: ENSOCARE_RESPONSES_CODE[ENSOCARE_RESPONSES.accept],
+        requireComment: true,
+    },
 };
 
 export function getEnsocareResponseOptionsConfigs() {

--- a/src/tasks/referralResponse/ensocare/responseOptionsBuilder.ts
+++ b/src/tasks/referralResponse/ensocare/responseOptionsBuilder.ts
@@ -1,0 +1,294 @@
+import { ResponseOption, ResponseReasonOption } from "../base/responseOptions";
+import { ENSOCARE_RESPONSES, ENSOCARE_RESPONSES_CODE, EnsocareResponseOption } from "./constants";
+
+/** Ensocare reason option — value is the numeric catalog entry id. */
+export interface EnsocareReasonOption extends ResponseReasonOption {
+    value: number;
+}
+
+/** Ensocare response option — value is the numeric action code (1/2/3). */
+export interface EnsocareOption extends ResponseOption {
+    value: number;
+    responseReasonOptions?: EnsocareReasonOption[];
+}
+
+export type EnsocareResponseConfigs = { [key: string]: EnsocareOption };
+
+/**
+ * One entry of the Ensocare response-reason catalog
+ * (GET /dischargeservice/api/provider/response/reasons), as captured verbatim.
+ * `actionId` links the reason to its action (1 = Yes, 2 = No, 3 = Considering);
+ * a reason is only identified by `(id, actionId)` — the same description can exist
+ * under multiple actions with different ids.
+ */
+export type EnsocareResponseReasonCatalogEntry = {
+    id: number;
+    description: string;
+    responseTypeCode: number;
+    active: boolean;
+    actionId: number;
+};
+
+/**
+ * Hardcoded from the Jewel client capture (2026-08-02). Managed on our end by
+ * decision — see EpicPiedmont drafts/ensocare_resposne/ensocare-response-reasons.md.
+ * The scraper's drift guard compares THIS constant against the live endpoint before
+ * submitting; the Front builds its options from it. One source of truth.
+ */
+export const ENSOCARE_REASONS_CATALOG: readonly EnsocareResponseReasonCatalogEntry[] = Object.freeze([
+    {
+        id: 44,
+        description: "1:1 Sitter must be discontinued",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 16,
+        description: "Admission application form needed",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 41,
+        description: "Behavioral issues",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 57,
+        description: "Inability to staff",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 22,
+        description: "Inability to staff",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 39,
+        description: "Insufficient funding for care needs",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 51,
+        description: "Insurance denied",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 29,
+        description: "Insurance out of network",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 21,
+        description: "Insurance out of network",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 52,
+        description: "Lack of firm discharge plan",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 49,
+        description: "Medicaid pending",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 50,
+        description: "Medicaid pending",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 27,
+        description: "Medication list needed",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 14,
+        description: "Need more information - see notes",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 42,
+        description: "Negative history with patient",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 2,
+        description: "No bed available",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 33,
+        description: "No isolation bed",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 37,
+        description: "Not a covered benefit",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 53,
+        description: "Not approved by physician",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 56,
+        description: "Out of service area",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 36,
+        description: "Patient benefits are exhausted",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 47,
+        description: "Patient does not meet criteria (payer guidelines)",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 12,
+        description: "Pending ID/PASRR completion",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 8,
+        description: "Pending nurse evaluation",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 25,
+        description: "Pending orders - see notes",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 17,
+        description: "Please call to discuss",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 40,
+        description: "Social issues (ETOH/drug, criminal history)",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 54,
+        description: "Too high functioning",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 55,
+        description: "Too low functioning",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 1,
+        description: "Unable to meet specialty/medical needs",
+        responseTypeCode: 2,
+        active: true,
+        actionId: 2,
+    },
+    {
+        id: 11,
+        description: "Verifying insurance",
+        responseTypeCode: 3,
+        active: true,
+        actionId: 3,
+    },
+    {
+        id: 32,
+        description: "We can accept this patient. Thank you for your referral",
+        responseTypeCode: 1,
+        active: true,
+        actionId: 1,
+    },
+]);
+
+/** Reasons of one action as UI options — displayValue: description, value: id. */
+function reasonOptionsForAction(actionId: number): EnsocareReasonOption[] {
+    return ENSOCARE_REASONS_CATALOG.filter((entry) => entry.actionId === actionId && entry.active).map((entry) => ({
+        displayValue: entry.description,
+        value: entry.id,
+    }));
+}
+
+/** displayValue/value pair of one action — mirrors aidin's helper. */
+function buildOption(displayValue: EnsocareResponseOption): EnsocareOption {
+    const value = ENSOCARE_RESPONSES_CODE[displayValue];
+    return { displayValue, value, responseReasonOptions: reasonOptionsForAction(value) };
+}
+
+const ensocareResponseOptions: EnsocareResponseConfigs = {
+    // Accept deliberately has NO reason options: its single catalog reason
+    // (actionId 1, id 32 "We can accept this patient...") is appended
+    // automatically by the automation side when submitting a Yes response —
+    // the user is never asked to pick it.
+    [ENSOCARE_RESPONSES.accept]: {
+        displayValue: ENSOCARE_RESPONSES.accept,
+        value: ENSOCARE_RESPONSES_CODE[ENSOCARE_RESPONSES.accept],
+    },
+    [ENSOCARE_RESPONSES.decline]: buildOption(ENSOCARE_RESPONSES.decline),
+    [ENSOCARE_RESPONSES.considering]: buildOption(ENSOCARE_RESPONSES.considering),
+};
+
+export function getEnsocareResponseOptionsConfigs() {
+    return ensocareResponseOptions;
+}

--- a/src/tasks/referralResponse/index.ts
+++ b/src/tasks/referralResponse/index.ts
@@ -1,4 +1,6 @@
 export * as Navi from "./navi";
 export * as Aidin from "./aidin"
+export * as Base from "./base";
+export * as Ensocare from "./ensocare";
 export * as constants from "./constants";
 

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -55,6 +55,10 @@ export interface AvailableSite {
     responseStatus?: string;
     respondByDate?: string;
     lastActivityDate?: string;
+    /** Can the provider still submit a status response for THIS site? Task-level {@link SelectPatientCallbackData.isRespondEnabled} aggregates these (any-enabled). */
+    isRespondEnabled?: boolean;
+    /** Is free-text messaging available for THIS site? Ensocare: true only for Booked referrals (message-only state). */
+    isMessageEnabled?: boolean;
 }
 
 /**

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -63,6 +63,14 @@ export interface AvailableSite {
  * narrow to this when reading the selectPatient result.
  */
 export interface SelectPatientCallbackData {
+    /** Can the provider still submit a status response for this referral? */
+    isRespondEnabled?: boolean;
+    /** Is free-text messaging available (often true even when responding is closed)? */
+    isMessageEnabled?: boolean;
+    /** Human-readable reason when responding is disabled. */
+    displayMsg?: string;
+    /** Typed reason code (scraper statusCodes, e.g. response_deadline_passed). */
+    statusCode?: string;
     availableSites?: AvailableSite[];
 }
 


### PR DESCRIPTION
## TL;DR
Adds full EnsoCare referral-response support to the types package — a new reusable base task contract, EnsoCare task types and response-option catalog, status mappings, and the `executingAccountMode` config contract.

## Summary
This PR introduces the type-level foundation for automating referral responses in EnsoCare. Instead of duplicating the Aidin task shapes, it extracts a generic `base` referral-response contract (facility responses, response/selectPatient tasks, response-option configs) and builds both the new `Ensocare` module and the existing `Aidin` module on top of it. It also ships the hardcoded EnsoCare response-reason catalog that serves as the single source of truth for the Front's option UI and the scraper's drift guard.

## Scope of Changes
- **Feature**: New `tasks/referralResponse/base` module — generic `FacilityResponse`, `ReferralResponseData<F>`, `SelectPatientData`, `ResponseTask<SRC, DATA>`, `SelectPatientTask<SRC, DATA>`, and the `ResponseOption`/`ResponseReasonOption`/`ResponseConfigs` option contracts (`base/index.ts`, `base/responseOptions.ts`).
- **Feature**: New `tasks/referralResponse/ensocare` module — `EnsocareFacilityResponse`, `EnsocareReferralResponseData`, `EnsocareSelectPatientData` (with `mrn`), task types, response constants (`ENSOCARE_RESPONSES`, `ENSOCARE_RESPONSES_CODE`, `ENSOCARE_MESSAGE_RESPONSES`), and `responseOptionsBuilder.ts` with the captured `ENSOCARE_REASONS_CATALOG` and `getEnsocareResponseOptionsConfigs()`.
- **Feature**: EnsoCare status mappings (`ensocareStatuses.ts`) and an `ensocare` `SystemSpecificStatusParser` registered in `systemsParserFunctions.ts`.
- **Feature**: `EhrType.Ensocare = "EnsoCare"` in `ehr.ts`.
- **Feature**: `ResponseEhrConfigDocument` with `executingAccountMode` (`EXECUTING_ACCOUNT_MODE`: `perUserAccount` / `perFacilityAccount` / `fixedAccount`) in `settings/ehrConfigs.ts` and `referralResponse/constants.ts`.
- **Feature**: `AvailableSite.isRespondEnabled` / `isMessageEnabled` and `SelectPatientCallbackData.isRespondEnabled` / `isMessageEnabled` / `displayMsg` / `statusCode` in `tasks/types.ts`.
- **Refactor**: `tasks/referralResponse/aidin/index.ts` re-based onto the new base contract — identical shapes, plus the optional `ehrReferralIdOfSite` inherited from `Base.FacilityResponse`.
- **Config**: `package.json` export maps for `tasks/referralResponse/base` and `tasks/referralResponse/ensocare`; version bump `1.1.115` → `1.1.117`.

## Technical Implementation Details
- **Base contract extraction**: `ResponseTask<SRC, DATA>` and `SelectPatientTask<SRC, DATA>` are generic over the source system and payload, keyed to `TASK_SUB_TYPE.response` / `TASK_SUB_TYPE.selectPatient`, so every EHR module declares its task types in one line. `Aidin` now extends these; `Navi` predates the contract and is intentionally left as-is.
- **`ehrReferralIdOfSite`**: added to `Base.FacilityResponse` as the id of the site's specific referral entry in the EHR (EnsoCare's per-facility referral row id, AllScripts' `connectionId`) — distinct from the facility/organization id. Optional in the base; required in `EnsocareFacilityResponse` since EnsoCare's respond call targets it directly.
- **`response ?? displayValue` mapping contract**: `ResponseOption` gains an optional `response` field letting an option display one label while submitting a different canonical value. The "Message Booked Referral" option uses it to submit as `"Yes"` (statusCode `1`), so the scraper's accept path — including automation-side accept-reason enrichment — applies unchanged. Options that omit `response` behave exactly as before.
- **Hardcoded reason catalog**: `ENSOCARE_REASONS_CATALOG` captures the EnsoCare `provider/response/reasons` endpoint verbatim (a reason is identified by `(id, actionId)` — the same description can appear under multiple actions). The Front builds reason options from it via `reasonOptionsForAction()`; the scraper's drift guard compares it against the live endpoint before submitting. The Accept option deliberately exposes no reason options — its single catalog reason (id `32`) is appended automatically by the automation side.
- **`executingAccountMode`**: `ResponseEhrConfigDocument` intersects the srcType's own `EhrConfigDocument` with the response-process fields, declaring how a response process pulls tasks and which account executes them (per-user, per-facility-designated, or a single fixed account from the ehrConfig document).

## Testing & Validation
- This is a types-only package — validation is compile-time: `npm run build` (`tsc`) passes and CI builds the package on the branch.
- No runtime test suite exists in this repo; consumers (Server, Front, Puppeteer) type-check against the published contract.
- The `Aidin` refactor was verified to be shape-compatible: all previous fields are preserved via `Base.FacilityResponse` inheritance, with only the optional `ehrReferralIdOfSite` added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## EnsoCare Referral Responses

- Added EnsoCare referral-response support.
- Added response options, response reasons, and comment requirements.
- Added EnsoCare status mappings.
- Added response and messaging availability indicators.
- Added `executingAccountMode` support.
- Reused the shared referral-response contract for Aidin.
- Updated package exports and type declarations.

**Contributors:** `@dormoyalSnfai`, `@vaismav`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->