### PR TITLE
snf-571 add ensocare VA to ehr types

### DIFF
--- a/src/ehr.ts
+++ b/src/ehr.ts
@@ -10,5 +10,6 @@ export enum EhrType {
   EpicUMMS = 'Epic UMMS',
   EpicTrinityHealth = 'Epic Trinity-Health',
   Aida = "Aida",
-  Ensocare = "EnsoCare"
+  Ensocare = "EnsoCare",
+  EnsocareVA = "EnsoCare VA"
 }


### PR DESCRIPTION
## TL;DR
Add `EnsocareVA` as a new `EhrType` enum value to support Ensocare VA sites in downstream referral reporting.

## Summary
Extends the shared `EhrType` enum with an `EnsocareVA` value so consuming services (e.g. WorkflowServer's referral response report) can distinguish Ensocare VA sites from standard Ensocare sites and route them through dedicated parsing logic.

## Scope of Changes
- **Feature**: Added `EnsocareVA = "EnsoCare VA"` to the `EhrType` enum in `src/ehr.ts`.

## Technical Implementation Details
Single-value addition to the existing `EhrType` enum, following the same string-literal convention as `Ensocare`. No other type or interface changes.

## Testing & Validation
No behavioral logic in this package to test directly; the new enum value is a compile-time constant. Validated by downstream consumption in WorkflowServer (`EhrType.EnsocareVA`), which resolves and type-checks against this package once bumped to `1.1.119`.